### PR TITLE
Fix CrawlBar app resource bundle install

### DIFF
--- a/Formula/crawlbar.rb
+++ b/Formula/crawlbar.rb
@@ -1,8 +1,8 @@
 class Crawlbar < Formula
   desc "macOS menu bar control plane for local-first crawler CLIs"
   homepage "https://github.com/openclaw/crawlbar"
-  url "https://github.com/openclaw/crawlbar/archive/refs/tags/v0.2.0.tar.gz"
-  sha256 "a945ac57178f143173b00512135eb30b8b69bf31b680f805fcd2805ede81421e"
+  url "https://github.com/openclaw/crawlbar/archive/refs/tags/v0.2.1.tar.gz"
+  sha256 "f714081d00aa5d8f55f9985be65f5b32f454d04d14644c157ea3dfefbf81d821"
   license "MIT"
   head "https://github.com/openclaw/crawlbar.git", branch: "main"
 
@@ -43,7 +43,7 @@ class Crawlbar < Formula
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleShortVersionString</key>
-        <string>0.2.0</string>
+        <string>0.2.1</string>
         <key>CFBundleVersion</key>
         <string>1</string>
         <key>LSUIElement</key>

--- a/Formula/crawlbar.rb
+++ b/Formula/crawlbar.rb
@@ -15,6 +15,7 @@ class Crawlbar < Formula
 
     app_binary = Pathname(Dir[".build/**/release/CrawlBar"].first)
     cli_binary = Pathname(Dir[".build/**/release/crawlbarctl"].first)
+    resource_bundle = Pathname(Dir[".build/**/release/CrawlBar_CrawlBar.bundle"].first)
 
     app = prefix/"CrawlBar.app"
     contents = app/"Contents"
@@ -23,6 +24,7 @@ class Crawlbar < Formula
     resources = contents/"Resources"
     macos.install app_binary
     helpers.install cli_binary => "crawlbar"
+    app.install resource_bundle
     bin.write_exec_script helpers/"crawlbar"
     system "Scripts/generate_app_icon.swift", resources/"CrawlBar.icns"
     (contents/"Info.plist").write <<~PLIST
@@ -65,5 +67,6 @@ class Crawlbar < Formula
 
   test do
     assert_match "crawlbar commands:", shell_output("#{bin}/crawlbar --help")
+    assert_path_exists prefix/"CrawlBar.app/CrawlBar_CrawlBar.bundle/google.png"
   end
 end


### PR DESCRIPTION
## Summary

Fixes the CrawlBar Homebrew formula so the macOS app installs the SwiftPM resource bundle required by the current 0.2.0 binary.

The installed app was crashing in Settings because `Bundle.module` looked for `CrawlBar_CrawlBar.bundle`, but the formula only installed the executable, helper, and app icon. Copying the resource bundle into `CrawlBar.app` matches the lookup path generated by SwiftPM for this executable target, and the formula test now asserts the app resource exists.

## Verification

- `ruby -c Formula/crawlbar.rb`
- `python3 -m unittest tests/test_update_formula.py`
- `git diff --check`
- `brew test crawlbar`

Note: `brew reinstall --build-from-source ./Formula/crawlbar.rb` was attempted for local proof, but Homebrew rejects formula path installs outside its tap checkout.
