### PR TITLE
fix: declare wacli formula version

### DIFF
--- a/Formula/wacli.rb
+++ b/Formula/wacli.rb
@@ -1,6 +1,7 @@
 class Wacli < Formula
   desc "WhatsApp CLI built on whatsmeow"
   homepage "https://github.com/openclaw/wacli"
+  version "0.11.0"
   license "MIT"
   head "https://github.com/openclaw/wacli.git", branch: "main"
   on_macos do


### PR DESCRIPTION
Closed at Vitor's request. The local Homebrew installation had already been corrected, and we are removing the fork/branch cleanup trail instead of keeping this draft PR open.