### PR TITLE
fix: correct slacrawl formula test

### DIFF
--- a/Formula/slacrawl.rb
+++ b/Formula/slacrawl.rb
@@ -29,6 +29,6 @@ class Slacrawl < Formula
   end
 
   test do
-    assert_match "Usage of slacrawl:", shell_output("#{bin}/slacrawl --help", 1)
+    assert_match "Usage of slacrawl:", shell_output("#{bin}/slacrawl --help")
   end
 end


### PR DESCRIPTION
## Summary

- expect Slacrawl `--help` to exit successfully in the Homebrew formula test
- fixes the failing `brew test openclaw/tap/slacrawl` check for v0.7.6

## Verification

- `ruby -c Formula/slacrawl.rb`
- `brew style Formula/slacrawl.rb`
- `python3 -m unittest discover -s tests -v`
- installed v0.7.6 binary returns exit 0 and prints the expected usage text
