### PR TITLE
crawlbar: install signed v0.4.1 release app

### DIFF
--- a/Formula/crawlbar.rb
+++ b/Formula/crawlbar.rb
@@ -1,58 +1,21 @@
 class Crawlbar < Formula
   desc "macOS menu bar control plane for local-first crawler CLIs"
   homepage "https://github.com/openclaw/crawlbar"
-  url "https://github.com/openclaw/crawlbar/archive/refs/tags/v0.4.0.tar.gz"
-  sha256 "f4ba18c1f1d10f6ee64a06167fc9cd7400b9b1fd5e0e7ea10d6cf87635dedc88"
+  url "https://github.com/openclaw/crawlbar/releases/download/v0.4.1/CrawlBar-v0.4.1-macos.zip"
+  sha256 "5733d7151d0ec45c4d9cab877d3100654a964e57cb0772dc4bc27807d9509a85"
   license "MIT"
-  head "https://github.com/openclaw/crawlbar.git", branch: "main"
 
   depends_on macos: :sonoma
-  uses_from_macos "swift" => :build
 
   def install
-    system "swift", "build", "-c", "release", "--disable-sandbox", "--product", "CrawlBar"
-    system "swift", "build", "-c", "release", "--disable-sandbox", "--product", "crawlbarctl"
+    if (buildpath/"CrawlBar.app").directory?
+      prefix.install "CrawlBar.app"
+    else
+      odie "release archive does not contain CrawlBar.app/Contents" unless (buildpath/"Contents/Info.plist").exist?
 
-    app_binary = Pathname(Dir[".build/**/release/CrawlBar"].first)
-    cli_binary = Pathname(Dir[".build/**/release/crawlbarctl"].first)
-    resource_bundle = Pathname(Dir[".build/**/release/CrawlBar_CrawlBar.bundle"].first)
-
-    app = prefix/"CrawlBar.app"
-    contents = app/"Contents"
-    macos = contents/"MacOS"
-    helpers = contents/"Helpers"
-    resources = contents/"Resources"
-    macos.install app_binary
-    helpers.install cli_binary => "crawlbar"
-    app.install resource_bundle
-    bin.write_exec_script helpers/"crawlbar"
-    system "Scripts/generate_app_icon.swift", resources/"CrawlBar.icns"
-    (contents/"Info.plist").write <<~PLIST
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>CFBundleExecutable</key>
-        <string>CrawlBar</string>
-        <key>CFBundleIdentifier</key>
-        <string>com.vincentkoc.CrawlBar</string>
-        <key>CFBundleName</key>
-        <string>CrawlBar</string>
-        <key>CFBundleIconFile</key>
-        <string>CrawlBar</string>
-        <key>CFBundlePackageType</key>
-        <string>APPL</string>
-        <key>CFBundleShortVersionString</key>
-        <string>0.4.0</string>
-        <key>CFBundleVersion</key>
-        <string>1</string>
-        <key>LSUIElement</key>
-        <true/>
-      </dict>
-      </plist>
-    PLIST
-
-    doc.install "README.md", "LICENSE", "CONTRIBUTING.md"
+      (prefix/"CrawlBar.app").install "Contents"
+    end
+    bin.write_exec_script prefix/"CrawlBar.app/Contents/Helpers/crawlbar"
   end
 
   def caveats
@@ -66,7 +29,25 @@ class Crawlbar < Formula
   end
 
   test do
+    app = prefix/"CrawlBar.app"
+    signature = shell_output("codesign -d --verbose=4 #{app} 2>&1")
+    architectures = shell_output("lipo -archs #{app}/Contents/MacOS/CrawlBar")
+    bundle_id = shell_output("/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' #{app}/Contents/Info.plist")
+    bundle_version = shell_output(
+      "/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' #{app}/Contents/Info.plist",
+    )
+
     assert_match "crawlbar commands:", shell_output("#{bin}/crawlbar --help")
-    assert_path_exists prefix/"CrawlBar.app/CrawlBar_CrawlBar.bundle/google.png"
+    assert_path_exists app/"Contents/Resources/CrawlBar_CrawlBar.bundle/google.png"
+    assert_equal "com.vincentkoc.CrawlBar", bundle_id.strip
+    assert_equal version.to_s, bundle_version.strip
+    assert_match "Authority=Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)", signature
+    assert_match "TeamIdentifier=FWJYW4S8P8", signature
+    assert_match "flags=0x10000(runtime)", signature
+    assert_match "arm64", architectures
+    assert_match "x86_64", architectures
+    system "codesign", "--verify", "--deep", "--strict", app
+    system "spctl", "--assess", "--type", "execute", app
+    system "xcrun", "stapler", "validate", app
   end
 end

--- a/tests/test_formulae.py
+++ b/tests/test_formulae.py
@@ -8,6 +8,15 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
 class FormulaTest(unittest.TestCase):
+    def test_crawlbar_installs_trusted_release_app(self) -> None:
+        text = (ROOT / "Formula" / "crawlbar.rb").read_text()
+        self.assertIn("/releases/download/", text)
+        self.assertIn("CrawlBar-v", text)
+        self.assertIn("Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)", text)
+        self.assertNotIn("/archive/refs/tags/", text)
+        self.assertNotIn('system "swift"', text)
+        self.assertNotIn('head "', text)
+
     def test_wacli_head_build_declares_go(self) -> None:
         text = (ROOT / "Formula" / "wacli.rb").read_text()
         self.assertIn('depends_on "go" => :build if build.head?', text)


### PR DESCRIPTION
## Summary

- replace CrawlBar's source-build Formula with the notarized v0.4.1 release app
- preserve the existing Formula name and `com.vincentkoc.CrawlBar` bundle identity for upgrades
- verify Foundation Developer ID signing, hardened runtime, universal architectures, Gatekeeper, and stapled notarization in `brew test`
- guard CI against restoring a source archive, Swift build, or unsigned `head` path

## Proof

- public release SHA-256: `5733d7151d0ec45c4d9cab877d3100654a964e57cb0772dc4bc27807d9509a85`
- 16 updater/security tests pass
- `brew style Formula/*.rb`
- `brew audit --strict --online openclaw/tap/crawlbar`
- updater dispatch dry run resolves the same URL and hash
- clean install and `brew test` pass
- installed app files match a fresh public archive extraction
- installed app passes strict codesign, exact authority/team/bundle/version, Gatekeeper, stapler, Apple distribution, CLI, and launch smoke
- autoreview clean; no findings
