### PR TITLE
feat: add axorc 0.1.6 formula

### DIFF
--- a/Formula/axorc.rb
+++ b/Formula/axorc.rb
@@ -1,0 +1,29 @@
+class Axorc < Formula
+  desc "Inspect and automate macOS Accessibility from the shell"
+  homepage "https://github.com/openclaw/AXorcist"
+  url "https://github.com/openclaw/AXorcist/releases/download/v0.1.6/axorc-0.1.6-macos-universal.zip"
+  sha256 "4db12ffa2feeb455c7b5bf3263cb711289523f5dfbe1f7a911baa03ad9150049"
+  license "MIT"
+
+  depends_on macos: :sonoma
+
+  skip_clean "bin/axorc"
+
+  def install
+    bin.install "axorc"
+  end
+
+  def caveats
+    <<~EOS
+      axorc requires Accessibility permission:
+        System Settings > Privacy & Security > Accessibility
+    EOS
+  end
+
+  test do
+    assert_match "axorc #{version}", shell_output("#{bin}/axorc --version")
+    assert_match "USAGE:", shell_output("#{bin}/axorc --help")
+    system "/usr/bin/codesign", "--verify", "--strict", bin/"axorc"
+    assert_match "anchor apple generic", shell_output("/usr/bin/codesign -d -r- #{bin}/axorc 2>&1")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ brew install --cask openclaw/tap/<name>
 
 ### Formulae
 
+- `axorc` — Inspect and automate macOS Accessibility from the shell
 - `crabbox` — Remote Linux test boxes for dirty worktrees and CI hydration
 - `crabfleet` — Fleet management CLI for Crabbox workers
 - `crawlbar` — macOS menu bar control plane for local-first crawler CLIs

--- a/tests/test_formulae.py
+++ b/tests/test_formulae.py
@@ -8,6 +8,14 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
 class FormulaTest(unittest.TestCase):
+    def test_axorc_installs_trusted_release_binary(self) -> None:
+        text = (ROOT / "Formula" / "axorc.rb").read_text()
+        self.assertIn("/releases/download/", text)
+        self.assertIn('skip_clean "bin/axorc"', text)
+        self.assertIn("anchor apple generic", text)
+        self.assertNotIn("/archive/refs/tags/", text)
+        self.assertNotIn('system "swift"', text)
+
     def test_crawlbar_installs_trusted_release_app(self) -> None:
         text = (ROOT / "Formula" / "crawlbar.rb").read_text()
         self.assertIn("/releases/download/", text)


### PR DESCRIPTION
## Summary

- add the signed universal `axorc` 0.1.6 release formula
- preserve its Developer ID signature during Homebrew installation
- document the formula and guard its binary distribution contract

## Verification

- `python3 -m unittest discover -s tests -v`
- `brew style Formula/axorc.rb`
- `brew audit --strict codex/axorc/axorc`
- `brew install --formula codex/axorc/axorc`
- `brew test codex/axorc/axorc`
- `axorc --version`, `axorc --help`, and `axorc permissions --json`
- installed binary byte-identical to the public release binary
- installed binary passes strict code-signature verification with an `anchor apple generic` designated requirement

Release: https://github.com/openclaw/AXorcist/releases/tag/v0.1.6
