### PR TITLE
chore: update Crabbox to 0.38.4

### DIFF
--- a/Formula/crabbox.rb
+++ b/Formula/crabbox.rb
@@ -5,13 +5,13 @@
 class Crabbox < Formula
   desc "Remote software testing and execution"
   homepage "https://github.com/openclaw/crabbox"
-  version "0.38.3"
+  version "0.38.4"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/openclaw/crabbox/releases/download/v0.38.3/crabbox_0.38.3_darwin_amd64.tar.gz"
-      sha256 "ab486626875474c65995c163ae1342fbc6c99dcfe417e061f5cc1a44c0c669e1"
+      url "https://github.com/openclaw/crabbox/releases/download/v0.38.4/crabbox_0.38.4_darwin_amd64.tar.gz"
+      sha256 "03ebcc6e24a5d6296b72e55bcb2759fa7e404445d9eb9f1a88f932da63b20e4f"
 
       define_method(:install) do
         bin.install "crabbox"
@@ -19,8 +19,8 @@ class Crabbox < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/openclaw/crabbox/releases/download/v0.38.3/crabbox_0.38.3_darwin_arm64.tar.gz"
-      sha256 "42512399e1723e6adbd96451daec68ec551c97e0cd93689b036f05423668708b"
+      url "https://github.com/openclaw/crabbox/releases/download/v0.38.4/crabbox_0.38.4_darwin_arm64.tar.gz"
+      sha256 "0aa84793bbf2068804f6879f023cdd45e68bfd9873db3990292bfac109b68c80"
 
       define_method(:install) do
         bin.install "crabbox"
@@ -31,16 +31,16 @@ class Crabbox < Formula
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
-      url "https://github.com/openclaw/crabbox/releases/download/v0.38.3/crabbox_0.38.3_linux_amd64.tar.gz"
-      sha256 "2d8f060f39815a87707d20d35cf81bfd69fa80f6d0f3e849274df149b8825dd9"
+      url "https://github.com/openclaw/crabbox/releases/download/v0.38.4/crabbox_0.38.4_linux_amd64.tar.gz"
+      sha256 "c2e56aeb3df904438202cef849221e1f5f824c7838b7956e00722f883342f4ab"
       define_method(:install) do
         bin.install "crabbox"
         bin.install "crabbox-apple-vm-helper" if OS.mac? && Hardware::CPU.arm?
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/openclaw/crabbox/releases/download/v0.38.3/crabbox_0.38.3_linux_arm64.tar.gz"
-      sha256 "a26c0f94986bcb0189de85f27de0dd9273c3cbfde4582632af9124431651b388"
+      url "https://github.com/openclaw/crabbox/releases/download/v0.38.4/crabbox_0.38.4_linux_arm64.tar.gz"
+      sha256 "a3aed9e81a4a80a9ba860c302ba5eb6c3e7bf6034c9d7606cd1b10a273a86493"
       define_method(:install) do
         bin.install "crabbox"
         bin.install "crabbox-apple-vm-helper" if OS.mac? && Hardware::CPU.arm?


### PR DESCRIPTION
## Summary

Update the Crabbox formula to the verified v0.38.4 release.

Release: https://github.com/openclaw/crabbox/releases/tag/v0.38.4
Public verifier: https://github.com/openclaw/crabbox/actions/runs/29511083328

## Verification

- Formula is byte-for-byte output from the protected Crabbox renderer.
- All eight public release assets downloaded successfully.
- Darwin amd64, Darwin arm64, Linux amd64, and Linux arm64 SHA-256 values match the public archives.
- Ruby syntax and git diff checks pass.
