### PR TITLE
fix: update slacrawl formula safely to v0.7.10

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -1256,6 +1256,7 @@ def main(argv: list[str] | None = None) -> int:
 
     text = path.read_text()
     text = update_repository_metadata(text, args.repository)
+    text = update_version(text, version)
     has_macos = has_stanza(text, "on_macos")
     has_linux = has_stanza(text, "on_linux")
     url_sha_pairs = iter_url_sha_pairs(text)
@@ -1292,8 +1293,6 @@ def main(argv: list[str] | None = None) -> int:
         has_target_urls = target_url_count > 1
     if has_macos != has_linux and not has_target_urls:
         raise SystemExit("formulae with only one platform stanza need manual updates")
-
-    text = update_version(text, version)
 
     if has_target_urls:
         template = args.artifact_template or "{formula}_{version}_{target}.tar.gz"

--- a/Formula/slacrawl.rb
+++ b/Formula/slacrawl.rb
@@ -1,26 +1,26 @@
 class Slacrawl < Formula
   desc "Go-based CLI for mirroring Slack workspace data into local SQLite"
   homepage "https://github.com/openclaw/slacrawl"
-  version "0.7.9"
+  version "0.7.10"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.9/slacrawl_0.7.9_darwin_arm64.tar.gz"
-      sha256 "37e884c41e8e75960e0672605738268243e8cba2fb9f254b3a2e2c68b2c1e374"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.10/slacrawl_0.7.10_darwin_arm64.tar.gz"
+      sha256 "5ecf5614e0a94eb7fcd960e5b7026bc4df3722013d5031764d918575fc65e1f6"
     else
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.9/slacrawl_0.7.9_darwin_amd64.tar.gz"
-      sha256 "b6418cd9fcaa66f8734eb35c7d294f1c54431230da97cbadf6e6f197485c8d88"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.10/slacrawl_0.7.10_darwin_amd64.tar.gz"
+      sha256 "f6ccfea96df62627fda5e233888eeea3a90f9e03c601f9e38a788dc6ac472421"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.9/slacrawl_0.7.9_linux_arm64.tar.gz"
-      sha256 "023f387c0133fa5e325ca40e4f6a508d06ff7d9f2ffe5882c5dade0ad7944718"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.10/slacrawl_0.7.10_linux_arm64.tar.gz"
+      sha256 "4bb12f5f8644903fd7b9df8f4c333c1ba166f4ec7895590725e7536c6f94321b"
     else
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.9/slacrawl_0.7.9_linux_amd64.tar.gz"
-      sha256 "222d7b2c1f506c52e9f4fa6bda20a3b88b83bda11ab369bd797e703fa1321f8f"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.10/slacrawl_0.7.10_linux_amd64.tar.gz"
+      sha256 "e6bbfd1fd343282dfc33427d6cf0df7c0f89f50c7e28400b34374825a8b4d93f"
     end
   end
 

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -505,6 +505,39 @@ end
         self.assertEqual(updated.count("v0.3.0.tar.gz"), 2)
         self.assertEqual(updated.count("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"), 2)
 
+    def test_target_update_handles_version_length_change(self) -> None:
+        formula = update_formula.seed_formula(
+            "example",
+            "openclaw/example",
+            "0.7.9",
+            "Example CLI",
+            "{formula}_{version}_{target}.tar.gz",
+        )
+        arguments = [
+            "--formula", "example",
+            "--tag", "v0.7.10",
+            "--repository", "openclaw/example",
+            "--artifact-template", "{formula}_{version}_{target}.tar.gz",
+        ]
+
+        previous_directory = pathlib.Path.cwd()
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "Formula").mkdir()
+            path = root / "Formula" / "example.rb"
+            path.write_text(formula)
+            os.chdir(root)
+            try:
+                with mock.patch.object(update_formula, "sha256", return_value="e" * 64):
+                    self.assertEqual(update_formula.main(arguments), 0)
+            finally:
+                os.chdir(previous_directory)
+            updated = path.read_text()
+
+        self.assertIn('version "0.7.10"', updated)
+        self.assertEqual(updated.count('sha256 "' + "e" * 64 + '"'), 4)
+        self.assertNotIn('""', updated)
+
     def test_rejects_different_architecture_urls_in_one_stanza(self) -> None:
         text = '''class Example < Formula
   version "1.0.0"


### PR DESCRIPTION
## Summary

- fix multi-architecture formula updates when the version string changes length
- add a regression test for the `0.7.9` to `0.7.10` transition
- update `Formula/slacrawl.rb` from the published v0.7.10 archives and their downloaded SHA-256 digests

## Root cause

The updater collected URL/checksum regex offsets before replacing the formula version. Expanding `0.7.9` to `0.7.10` shifted every later offset by one byte, so replacements dropped indentation and left an extra quote. The checksum manifest filename was not involved; the updater downloaded and hashed each archive directly.

## Validation

- `python3 -m unittest discover -s tests -v`
- Ruby syntax validation for every formula
- `brew style Formula/*.rb`
- structured Codex autoreview: no findings
