### PR TITLE
fix: remove redundant notcrawl formula version

### DIFF
--- a/Formula/notcrawl.rb
+++ b/Formula/notcrawl.rb
@@ -1,7 +1,6 @@
 class Notcrawl < Formula
   desc "Local-first Notion crawler into SQLite and normalized Markdown"
   homepage "https://github.com/openclaw/notcrawl"
-  version "0.5.6"
   license "MIT"
 
   on_macos do


### PR DESCRIPTION
## Summary

- remove the redundant explicit notcrawl version now derived from the v0.5.6 release URLs

This is the sole finding from `brew audit --strict openclaw/tap/notcrawl` after the verified v0.5.6 formula handoff.

## Verification

- 31 tap updater/workflow tests passed
- `ruby -c Formula/notcrawl.rb`
- `brew style Formula/notcrawl.rb`
- autoreview clean with no accepted/actionable findings
