### PR TITLE
feat: self-heal stale Homebrew formulae

### DIFF
--- a/.github/scripts/reconcile_formulae.py
+++ b/.github/scripts/reconcile_formulae.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Reconcile tap formulae with their latest stable GitHub releases."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import difflib
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import update_formula
+
+
+USER_AGENT = "openclaw-homebrew-tap-reconciler"
+SEMVER_PATTERN = re.compile(
+    r"^v?(?P<major>0|[1-9][0-9]*)\."
+    r"(?P<minor>0|[1-9][0-9]*)\."
+    r"(?P<patch>0|[1-9][0-9]*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+    r"(?:\+(?P<build>[0-9A-Za-z.-]+))?$"
+)
+HOMEPAGE_PATTERN = re.compile(
+    r'^\s*homepage\s+"https://github\.com/([^/"\s]+/[^/"\s]+)"\s*$',
+    re.MULTILINE,
+)
+VERSION_PATTERN = re.compile(r'^\s*version\s+"([^"]+)"\s*$', re.MULTILINE)
+FORMULA_PATTERN = re.compile(r"[a-z0-9][a-z0-9+@._-]*")
+
+
+@dataclasses.dataclass(frozen=True)
+class SemanticVersion:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...] = ()
+
+    def compare(self, other: "SemanticVersion") -> int:
+        core = (self.major, self.minor, self.patch)
+        other_core = (other.major, other.minor, other.patch)
+        if core != other_core:
+            return (core > other_core) - (core < other_core)
+        if not self.prerelease or not other.prerelease:
+            return (not self.prerelease) - (not other.prerelease)
+        for left, right in zip(self.prerelease, other.prerelease):
+            if left == right:
+                continue
+            left_numeric = left.isdigit()
+            right_numeric = right.isdigit()
+            if left_numeric and right_numeric:
+                return (int(left) > int(right)) - (int(left) < int(right))
+            if left_numeric != right_numeric:
+                return -1 if left_numeric else 1
+            return (left > right) - (left < right)
+        return (len(self.prerelease) > len(other.prerelease)) - (
+            len(self.prerelease) < len(other.prerelease)
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class FormulaInfo:
+    name: str
+    path: pathlib.Path
+    repository: str
+    current_tag: str
+    current_version: SemanticVersion
+    update_options: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class Release:
+    tag: str
+    draft: bool
+    prerelease: bool
+
+
+@dataclasses.dataclass
+class Summary:
+    scanned: int = 0
+    current: int = 0
+    drift: int = 0
+    updated: int = 0
+    refused: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
+class RateLimitError(RuntimeError):
+    """Raised when GitHub asks the bounded scan to stop making requests."""
+
+
+def parse_semver(value: str) -> SemanticVersion:
+    match = SEMVER_PATTERN.fullmatch(value)
+    if not match:
+        raise ValueError(f"{value!r} is not a semantic version")
+    prerelease = tuple((match.group("prerelease") or "").split("."))
+    if prerelease == ("",):
+        prerelease = ()
+    return SemanticVersion(
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+        prerelease,
+    )
+
+
+def source_release_urls(text: str, repository: str, version: str) -> list[tuple[str, str]]:
+    prefix = f"https://github.com/{repository}/releases/download/"
+    urls: list[tuple[str, str]] = []
+    for pair in update_formula.iter_url_sha_pairs(text):
+        url = pair.group("url").replace("#{version}", version)
+        if not url.lower().startswith(prefix.lower()):
+            continue
+        remainder = url[len(prefix) :]
+        if "/" not in remainder:
+            raise ValueError(f"release URL has no asset name: {url}")
+        tag, asset = remainder.split("/", 1)
+        urls.append((tag, asset))
+    return urls
+
+
+def marker_for_target(asset: str, target: str) -> str:
+    matches = [marker for marker in update_formula.target_markers(target) if marker in asset]
+    if not matches:
+        raise ValueError(f"cannot identify the {target} marker in {asset!r}")
+    return matches[0]
+
+
+def infer_update_options(
+    text: str,
+    repository: str,
+    formula: str,
+    current_tag: str,
+    version: str,
+) -> tuple[str, ...]:
+    release_urls = source_release_urls(text, repository, version)
+    if not release_urls:
+        raise ValueError("formula has no source-repository release asset URL/checksum pair")
+
+    if len(release_urls) == 1:
+        tag, asset = release_urls[0]
+        url_template = (
+            f"https://github.com/{repository}/releases/download/{{tag}}/"
+            + asset.replace(version, "{version}")
+        )
+        if tag != current_tag:
+            raise ValueError(f"release URL tag {tag!r} does not match current tag {current_tag!r}")
+        update_formula.validate_template(
+            url_template,
+            "reconciler artifact URL template",
+            frozenset(("formula", "version", "tag")),
+        )
+        return ("--artifact-url", url_template)
+
+    templates: set[str] = set()
+    aliases: dict[str, str] = {}
+    targets: set[str] = set()
+    for tag, asset in release_urls:
+        if tag != current_tag:
+            raise ValueError(f"release URL tag {tag!r} does not match current tag {current_tag!r}")
+        target = update_formula.classify_target(asset, {}, version)
+        if target not in update_formula.RELEASE_TARGETS:
+            raise ValueError(f"cannot classify release asset {asset!r}")
+        if target in targets:
+            raise ValueError(f"formula has duplicate {target} release assets")
+        targets.add(target)
+        marker = marker_for_target(asset, target)
+        aliases[target] = marker
+        templates.add(asset.replace(version, "{version}").replace(marker, "{target}", 1))
+
+    if len(templates) != 1:
+        raise ValueError(f"release assets do not share one artifact template: {sorted(templates)}")
+    template = templates.pop()
+    update_formula.validate_template(template, "reconciler artifact template")
+    options = ["--artifact-template", template]
+    noncanonical_aliases = [
+        f"{target}={aliases[target]}"
+        for target in update_formula.RELEASE_TARGETS
+        if target in aliases and aliases[target] != target
+    ]
+    if noncanonical_aliases:
+        options.extend(("--target-aliases", ",".join(noncanonical_aliases)))
+    return tuple(options)
+
+
+def parse_formula(path: pathlib.Path) -> FormulaInfo:
+    text = path.read_text()
+    homepages = HOMEPAGE_PATTERN.findall(text)
+    if len(homepages) != 1:
+        raise ValueError(f"expected one GitHub homepage, found {len(homepages)}")
+    repository = homepages[0]
+
+    versions = VERSION_PATTERN.findall(text)
+    if len(versions) > 1:
+        raise ValueError(f"expected at most one formula version, found {len(versions)}")
+    explicit_version = versions[0] if versions else None
+    release_urls = source_release_urls(text, repository, explicit_version or "")
+    if not release_urls:
+        raise ValueError("cannot infer current version without a source-repository release URL")
+
+    release_tags = {tag.replace("#{version}", explicit_version or "") for tag, _ in release_urls}
+    if len(release_tags) != 1:
+        raise ValueError(f"formula release URLs disagree on tag: {sorted(release_tags)}")
+    current_tag = release_tags.pop()
+    tag_version = parse_semver(current_tag)
+    if tag_version.prerelease:
+        raise ValueError(f"current formula tag {current_tag!r} is a prerelease")
+    if explicit_version is not None and parse_semver(explicit_version).compare(tag_version) != 0:
+        raise ValueError(f"formula version {explicit_version!r} does not match release tag {current_tag!r}")
+    version_text = explicit_version or current_tag.removeprefix("v")
+
+    return FormulaInfo(
+        name=path.stem,
+        path=path,
+        repository=repository,
+        current_tag=current_tag,
+        current_version=parse_semver(version_text),
+        update_options=infer_update_options(
+            text,
+            repository,
+            path.stem,
+            current_tag,
+            version_text,
+        ),
+    )
+
+
+def fetch_latest_release(repository: str) -> Release | None:
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}/releases/latest",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    token = os.environ.get("GH_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        if error.code in (403, 429):
+            retry_after = error.headers.get("Retry-After") or error.headers.get("X-RateLimit-Reset")
+            detail = f"; retry after/reset {retry_after}" if retry_after else ""
+            raise RateLimitError(f"GitHub API returned HTTP {error.code}{detail}") from error
+        raise RuntimeError(f"GitHub API returned HTTP {error.code}") from error
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"GitHub release lookup failed: {error}") from error
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("tag_name"), str):
+        raise RuntimeError("GitHub latest-release response has no tag_name")
+    return Release(
+        tag=payload["tag_name"],
+        draft=payload.get("draft") is True,
+        prerelease=payload.get("prerelease") is True,
+    )
+
+
+def run_update(root: pathlib.Path, info: FormulaInfo, latest_tag: str, dry_run: bool) -> None:
+    command = [
+        sys.executable,
+        str(pathlib.Path(__file__).with_name("update_formula.py")),
+        "--formula",
+        info.name,
+        "--tag",
+        latest_tag,
+        "--repository",
+        info.repository,
+        *info.update_options,
+    ]
+
+    if not dry_run:
+        subprocess.run(command, cwd=root, check=True)
+        return
+
+    with tempfile.TemporaryDirectory(prefix="tap-reconcile-") as directory:
+        scratch = pathlib.Path(directory)
+        (scratch / "Formula").mkdir()
+        scratch_formula = scratch / "Formula" / info.path.name
+        shutil.copy2(info.path, scratch_formula)
+        subprocess.run(command, cwd=scratch, check=True)
+        updated = scratch_formula.read_text()
+    original = info.path.read_text()
+    if updated == original:
+        raise RuntimeError("newer release produced no formula change")
+    print(
+        "".join(
+            difflib.unified_diff(
+                original.splitlines(keepends=True),
+                updated.splitlines(keepends=True),
+                fromfile=str(info.path),
+                tofile=f"{info.path} (reconciled)",
+            )
+        ),
+        end="",
+    )
+
+
+def formula_paths(root: pathlib.Path, selected: str | None) -> list[pathlib.Path]:
+    if selected:
+        if not FORMULA_PATTERN.fullmatch(selected):
+            raise ValueError(f"invalid formula {selected!r}")
+        path = root / "Formula" / f"{selected}.rb"
+        if not path.is_file():
+            raise ValueError(f"formula {selected!r} does not exist")
+        return [path]
+    return sorted((root / "Formula").glob("*.rb"))
+
+
+def reconcile(
+    root: pathlib.Path,
+    selected: str | None,
+    dry_run: bool,
+    release_lookup: Callable[[str], Release | None] = fetch_latest_release,
+    updater: Callable[[pathlib.Path, FormulaInfo, str, bool], None] = run_update,
+) -> Summary:
+    summary = Summary()
+    for path in formula_paths(root, selected):
+        summary.scanned += 1
+        try:
+            info = parse_formula(path)
+        except (OSError, ValueError) as error:
+            summary.skipped += 1
+            print(f"SKIP {path.stem}: {error}")
+            continue
+
+        try:
+            release = release_lookup(info.repository)
+        except RateLimitError as error:
+            summary.skipped += 1
+            print(f"BACKOFF {info.name}: {error}; stopping this bounded scan")
+            break
+        except RuntimeError as error:
+            summary.skipped += 1
+            print(f"SKIP {info.name}: {error}")
+            continue
+        if release is None:
+            summary.skipped += 1
+            print(f"SKIP {info.name}: {info.repository} has no published release")
+            continue
+        if release.draft or release.prerelease:
+            summary.skipped += 1
+            print(f"SKIP {info.name}: latest release {release.tag} is draft or prerelease")
+            continue
+        try:
+            latest_version = parse_semver(release.tag)
+        except ValueError as error:
+            summary.skipped += 1
+            print(f"SKIP {info.name}: {error}")
+            continue
+        if latest_version.prerelease:
+            summary.skipped += 1
+            print(f"SKIP {info.name}: tag {release.tag} has prerelease semantics")
+            continue
+
+        comparison = latest_version.compare(info.current_version)
+        if comparison < 0:
+            summary.refused += 1
+            print(f"REFUSE {info.name}: latest {release.tag} is older than current {info.current_tag}")
+            continue
+        if comparison == 0:
+            summary.current += 1
+            print(f"CURRENT {info.name}: {info.current_tag}")
+            continue
+
+        summary.drift += 1
+        print(f"DRIFT {info.name}: {info.current_tag} -> {release.tag}")
+        try:
+            updater(root, info, release.tag, dry_run)
+        except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
+            summary.failed += 1
+            print(f"FAILED {info.name}: {error}")
+            continue
+        summary.updated += 1
+        action = "WOULD UPDATE" if dry_run else "UPDATED"
+        print(f"{action} {info.name}: {info.current_tag} -> {release.tag}")
+
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--formula", help="Only reconcile this formula")
+    parser.add_argument("--dry-run", action="store_true", help="Verify and show updates without changing the checkout")
+    parser.add_argument("--root", type=pathlib.Path, default=pathlib.Path.cwd(), help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    try:
+        summary = reconcile(root, args.formula, args.dry_run)
+    except ValueError as error:
+        parser.error(str(error))
+    print(
+        "SUMMARY "
+        f"scanned={summary.scanned} current={summary.current} drift={summary.drift} "
+        f"updated={summary.updated} refused={summary.refused} skipped={summary.skipped} failed={summary.failed}"
+    )
+    return 1 if summary.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/reconcile-formulae.yml
+++ b/.github/workflows/reconcile-formulae.yml
@@ -1,0 +1,105 @@
+name: Reconcile Formulae
+run-name: Reconcile formulae${{ inputs.formula && format(' ({0})', inputs.formula) || '' }}${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && ' [dry run]' || '' }}
+
+on:
+  schedule:
+    - cron: "17 */3 * * *"
+  workflow_dispatch:
+    inputs:
+      formula:
+        description: "Optional single formula to inspect"
+        required: false
+        type: string
+      dry_run:
+        description: "Verify and report drift without committing"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: reconcile-formulae
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    if: >-
+      github.ref_protected == true &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+      endsWith(github.workflow_ref, format('@refs/heads/{0}', github.event.repository.default_branch))
+    runs-on: macos-15
+    steps:
+      - name: Checkout tap repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Setup Git
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git checkout -B "$DEFAULT_BRANCH" "$GITHUB_SHA"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Reconcile formulae
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || 'false' }}
+          FORMULA: ${{ github.event_name == 'workflow_dispatch' && inputs.formula || '' }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          args=()
+          if [ -n "$FORMULA" ]; then
+            args+=(--formula "$FORMULA")
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          python3 .github/scripts/reconcile_formulae.py "${args[@]}"
+
+      - name: Validate formulae
+        run: |
+          python3 -m unittest discover -s tests -v
+          for formula in Formula/*.rb; do
+            ruby -c "$formula"
+          done
+          brew style Formula/*.rb
+
+      - name: Commit and push
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || 'false' }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            git diff --exit-code
+            echo "Dry run left the checkout unchanged"
+            exit 0
+          fi
+
+          git add Formula/*.rb
+          if git diff --cached --quiet; then
+            echo "All formulae are current; no commit needed"
+            exit 0
+          fi
+
+          git commit -m "chore: reconcile Homebrew formulae"
+          gh auth setup-git
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:refs/heads/${DEFAULT_BRANCH}"; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "git push failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            git pull --rebase origin "$DEFAULT_BRANCH"
+            python3 -m unittest discover -s tests -v
+            for formula in Formula/*.rb; do
+              ruby -c "$formula"
+            done
+            brew style Formula/*.rb
+          done

--- a/Formula/clawscan.rb
+++ b/Formula/clawscan.rb
@@ -1,26 +1,26 @@
 class Clawscan < Formula
   desc "Agent-skill security scanner harness for ClawHub"
   homepage "https://github.com/openclaw/clawscan"
-  version "0.1.2"
+  version "0.1.6"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/openclaw/clawscan/releases/download/v#{version}/clawscan_v0.1.2_darwin_arm64.tar.gz"
-      sha256 "ece4716234e65c5e4c4a98c7b23677b8c5bf8edffc07e9607dd9bbda97578240"
+      url "https://github.com/openclaw/clawscan/releases/download/v0.1.6/clawscan_v0.1.6_darwin_arm64.tar.gz"
+      sha256 "fe3490da4cc3ebadc60972fa6a986be5d16280bbf281893458c7022044db6175"
     else
-      url "https://github.com/openclaw/clawscan/releases/download/v#{version}/clawscan_v0.1.2_darwin_amd64.tar.gz"
-      sha256 "70c0a37a9013e9dd00df928233a0544d75f1694b2e4562e92a220de66f3441e9"
+      url "https://github.com/openclaw/clawscan/releases/download/v0.1.6/clawscan_v0.1.6_darwin_amd64.tar.gz"
+      sha256 "115be8dc8bf12191ae117bc76ace6e399b6c840a9732c4b41b4191ccb19094ef"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/openclaw/clawscan/releases/download/v#{version}/clawscan_v0.1.2_linux_arm64.tar.gz"
-      sha256 "f15281ad4563938875b7e6f32a9c9d7dc3302555f7b5d352508745d956b217a8"
+      url "https://github.com/openclaw/clawscan/releases/download/v0.1.6/clawscan_v0.1.6_linux_arm64.tar.gz"
+      sha256 "2aec5286db54162b35eaf9d1f09f3b595e02769f5563c94c8186255550a56a50"
     else
-      url "https://github.com/openclaw/clawscan/releases/download/v#{version}/clawscan_v0.1.2_linux_amd64.tar.gz"
-      sha256 "243b54e8d0083f306aeaaa8feb0256e447b0ed78eb7230f59e123a1c7553338d"
+      url "https://github.com/openclaw/clawscan/releases/download/v0.1.6/clawscan_v0.1.6_linux_amd64.tar.gz"
+      sha256 "f477e6462f45ff021cc27b1baf2a85b0ad39aff88416af33910e2bec6655468a"
     end
   end
 

--- a/Formula/slacrawl.rb
+++ b/Formula/slacrawl.rb
@@ -1,26 +1,26 @@
 class Slacrawl < Formula
   desc "Go-based CLI for mirroring Slack workspace data into local SQLite"
   homepage "https://github.com/openclaw/slacrawl"
-  version "0.7.11"
+  version "0.8.3"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.11/slacrawl_0.7.11_darwin_arm64.tar.gz"
-      sha256 "f5fb7a78a5e521f79039ede436227914c237d867ebd4b752dd9fef518b98d597"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.3/slacrawl_0.8.3_darwin_arm64.tar.gz"
+      sha256 "2cd99ab6a1a45ec10ba46806f39c670b04fbbb3854fd736d89a367cbbaccc89f"
     else
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.11/slacrawl_0.7.11_darwin_amd64.tar.gz"
-      sha256 "8bc49a5e3402fdc4b24b53459d4b5cea5ff773c7879170be0b8f47fbf263f3f7"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.3/slacrawl_0.8.3_darwin_amd64.tar.gz"
+      sha256 "1adecc13d92190a674820195f19a4a3fb539f412dee1ad35f802f2dc4162f3ab"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.11/slacrawl_0.7.11_linux_arm64.tar.gz"
-      sha256 "f54bdb6bd391e41ebaab30d48d5796d4a0d7d4a6f000be959851ab1be84bf5a6"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.3/slacrawl_0.8.3_linux_arm64.tar.gz"
+      sha256 "80b50232947c8f4f5034e247e751d0058fe81a4ed9570b1d5a3d16b70c973cf8"
     else
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.7.11/slacrawl_0.7.11_linux_amd64.tar.gz"
-      sha256 "a83de7d59ae7ec5775612d7a1cbd89dac6a47fd03051b33fd5018009fc190061"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.3/slacrawl_0.8.3_linux_amd64.tar.gz"
+      sha256 "358c2cc53104232f518dd73ea96209e4d181cd3cb203f14003f53ecee312d7c1"
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,21 @@ brew uninstall --cask --zap openclaw/tap/<name>
 
 ## Maintainers
 
-The `Update Formula` workflow accepts a Homebrew formula token, a semantic release tag, and a
+Formula updates have two paths. Source-repository release workflows dispatch `Update Formula` for
+immediate updates. That workflow accepts a Homebrew formula token, a semantic release tag, and a
 GitHub repository in `owner/repo` form. Optional artifact inputs must resolve to HTTPS release
-assets and may use only the placeholders documented by the workflow. Pull requests and updates
-to `main` run the updater tests and validate every formula's Ruby syntax.
+assets and may use only the placeholders documented by the workflow.
+
+`Reconcile Formulae` is the self-healing fallback. Every three hours it derives each source
+repository from the formula's GitHub `homepage`, compares the formula with that repository's latest
+stable published release, and runs the same updater and checksum-download logic when the release is
+newer. It never downgrades, skips drafts and prereleases, and makes no commit when every formula is
+current. Manual reconciles default to dry-run and can target one formula. The reconciler reads public
+release metadata and pushes with this tap's own `GITHUB_TOKEN`; it needs no cross-repository token or
+other external credential. The dispatch path remains the preferred low-latency path.
+
+Pull requests and updates to `main` run the updater and reconciler tests and validate every formula's
+Ruby syntax.
 
 Fleet release workflows use the optional `assets` JSON contract: exactly one `name` and `sha256`
 for each Darwin/Linux amd64/arm64 target. The updater renders those names and hashes verbatim,

--- a/tests/test_reconcile_formulae.py
+++ b/tests/test_reconcile_formulae.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / ".github" / "scripts" / "reconcile_formulae.py"
+SPEC = importlib.util.spec_from_file_location("reconcile_formulae", SCRIPT)
+assert SPEC and SPEC.loader
+reconcile_formulae = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = reconcile_formulae
+SPEC.loader.exec_module(reconcile_formulae)
+
+
+def formula_text(version: str = "1.2.3") -> str:
+    return f'''class Example < Formula
+  desc "Example"
+  homepage "https://github.com/openclaw/example"
+  version "{version}"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/openclaw/example/releases/download/v{version}/example_v{version}_darwin_arm64.tar.gz"
+      sha256 "{'a' * 64}"
+    else
+      url "https://github.com/openclaw/example/releases/download/v{version}/example_v{version}_darwin_amd64.tar.gz"
+      sha256 "{'b' * 64}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/openclaw/example/releases/download/v{version}/example_v{version}_linux_arm64.tar.gz"
+      sha256 "{'c' * 64}"
+    else
+      url "https://github.com/openclaw/example/releases/download/v{version}/example_v{version}_linux_amd64.tar.gz"
+      sha256 "{'d' * 64}"
+    end
+  end
+end
+'''
+
+
+class ReconcileFormulaeTest(unittest.TestCase):
+    def make_tap(self, text: str = formula_text()) -> tuple[tempfile.TemporaryDirectory[str], pathlib.Path]:
+        directory = tempfile.TemporaryDirectory()
+        root = pathlib.Path(directory.name)
+        (root / "Formula").mkdir()
+        (root / "Formula" / "example.rb").write_text(text)
+        return directory, root
+
+    def test_semver_orders_prereleases_and_ignores_build_metadata(self) -> None:
+        stable = reconcile_formulae.parse_semver("v1.2.3")
+        prerelease = reconcile_formulae.parse_semver("1.2.3-rc.1")
+        newer = reconcile_formulae.parse_semver("1.2.4+build.7")
+        self.assertGreater(stable.compare(prerelease), 0)
+        self.assertLess(stable.compare(newer), 0)
+        self.assertEqual(stable.compare(reconcile_formulae.parse_semver("1.2.3+other")), 0)
+
+    def test_parses_homepage_version_and_custom_artifact_template(self) -> None:
+        directory, root = self.make_tap()
+        self.addCleanup(directory.cleanup)
+        info = reconcile_formulae.parse_formula(root / "Formula" / "example.rb")
+        self.assertEqual(info.repository, "openclaw/example")
+        self.assertEqual(info.current_tag, "v1.2.3")
+        self.assertEqual(
+            info.update_options,
+            ("--artifact-template", "example_v{version}_{target}.tar.gz"),
+        )
+
+    def test_every_checked_in_formula_has_a_reconcilable_release_shape(self) -> None:
+        formulae = sorted((ROOT / "Formula").glob("*.rb"))
+        self.assertTrue(formulae)
+        for path in formulae:
+            with self.subTest(formula=path.stem):
+                info = reconcile_formulae.parse_formula(path)
+                self.assertEqual(info.name, path.stem)
+                self.assertTrue(info.update_options)
+
+    def test_no_drift_does_not_run_updater_or_change_formula(self) -> None:
+        directory, root = self.make_tap()
+        self.addCleanup(directory.cleanup)
+        path = root / "Formula" / "example.rb"
+        before = path.read_text()
+        updates: list[str] = []
+        summary = reconcile_formulae.reconcile(
+            root,
+            None,
+            False,
+            release_lookup=lambda _: reconcile_formulae.Release("v1.2.3", False, False),
+            updater=lambda _root, _info, tag, _dry_run: updates.append(tag),
+        )
+        self.assertEqual(summary.current, 1)
+        self.assertEqual(summary.drift, 0)
+        self.assertEqual(updates, [])
+        self.assertEqual(path.read_text(), before)
+
+    def test_dry_run_detects_exactly_one_stale_formula(self) -> None:
+        directory, root = self.make_tap()
+        self.addCleanup(directory.cleanup)
+        second = formula_text().replace("Example", "Current").replace(
+            "openclaw/example", "openclaw/current"
+        ).replace("example", "current")
+        (root / "Formula" / "current.rb").write_text(second)
+        updates: list[tuple[str, str, bool]] = []
+
+        def latest(repository: str) -> reconcile_formulae.Release:
+            tag = "v1.2.4" if repository == "openclaw/example" else "v1.2.3"
+            return reconcile_formulae.Release(tag, False, False)
+
+        summary = reconcile_formulae.reconcile(
+            root,
+            None,
+            True,
+            release_lookup=latest,
+            updater=lambda _root, info, tag, dry_run: updates.append((info.name, tag, dry_run)),
+        )
+        self.assertEqual(summary.scanned, 2)
+        self.assertEqual(summary.drift, 1)
+        self.assertEqual(summary.updated, 1)
+        self.assertEqual(updates, [("example", "v1.2.4", True)])
+
+    def test_refuses_downgrade(self) -> None:
+        directory, root = self.make_tap()
+        self.addCleanup(directory.cleanup)
+        updates: list[str] = []
+        summary = reconcile_formulae.reconcile(
+            root,
+            None,
+            False,
+            release_lookup=lambda _: reconcile_formulae.Release("v1.2.2", False, False),
+            updater=lambda _root, _info, tag, _dry_run: updates.append(tag),
+        )
+        self.assertEqual(summary.refused, 1)
+        self.assertEqual(summary.drift, 0)
+        self.assertEqual(updates, [])
+
+    def test_skips_prerelease_even_if_release_flag_is_wrong(self) -> None:
+        directory, root = self.make_tap()
+        self.addCleanup(directory.cleanup)
+        updates: list[str] = []
+        summary = reconcile_formulae.reconcile(
+            root,
+            None,
+            False,
+            release_lookup=lambda _: reconcile_formulae.Release("v1.2.4-rc.1", False, False),
+            updater=lambda _root, _info, tag, _dry_run: updates.append(tag),
+        )
+        self.assertEqual(summary.skipped, 1)
+        self.assertEqual(updates, [])
+
+    def test_unparseable_formula_does_not_block_later_formulae(self) -> None:
+        directory, root = self.make_tap("class Broken < Formula\nend\n")
+        self.addCleanup(directory.cleanup)
+        (root / "Formula" / "working.rb").write_text(
+            formula_text().replace("Example", "Working").replace(
+                "openclaw/example", "openclaw/working"
+            ).replace("example", "working")
+        )
+        summary = reconcile_formulae.reconcile(
+            root,
+            None,
+            False,
+            release_lookup=lambda _: reconcile_formulae.Release("v1.2.3", False, False),
+        )
+        self.assertEqual(summary.scanned, 2)
+        self.assertEqual(summary.skipped, 1)
+        self.assertEqual(summary.current, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -11,6 +11,7 @@ import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 UPDATE_WORKFLOW = ROOT / ".github" / "workflows" / "update-formula.yml"
+RECONCILE_WORKFLOW = ROOT / ".github" / "workflows" / "reconcile-formulae.yml"
 CHECKOUT_SHA = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
 
 
@@ -73,6 +74,26 @@ class WorkflowSecurityTest(unittest.TestCase):
         self.assertIn("ref: ${{ github.sha }}", text)
         setup = named_step_run(text, "Setup Git")
         self.assertIn('git checkout -B "$DEFAULT_BRANCH" "$GITHUB_SHA"', setup)
+
+    def test_reconciler_is_bound_to_protected_default_branch_and_own_token(self) -> None:
+        text = RECONCILE_WORKFLOW.read_text()
+        self.assertIn("github.ref_protected == true", text)
+        self.assertIn(
+            "github.ref == format('refs/heads/{0}', github.event.repository.default_branch)",
+            text,
+        )
+        self.assertIn(
+            "endsWith(github.workflow_ref, format('@refs/heads/{0}', github.event.repository.default_branch))",
+            text,
+        )
+        self.assertIn("permissions:\n  contents: write", text)
+        self.assertIn("GH_TOKEN: ${{ github.token }}", text)
+        self.assertNotIn("TAP_TOKEN", text)
+        self.assertIn("persist-credentials: false", text)
+        self.assertIn("ref: ${{ github.sha }}", text)
+        self.assertIn('git diff --exit-code', named_step_run(text, "Commit and push"))
+        for block in run_blocks(text):
+            self.assertNotIn("${{ inputs.", block)
 
     def test_verified_handoff_has_exact_inputs_run_name_and_commit_trailers(self) -> None:
         text = UPDATE_WORKFLOW.read_text()


### PR DESCRIPTION
## Summary

- add a protected-branch reconciler that scans formula homepages every three hours and compares them with each repository's latest stable GitHub release
- reuse the existing formula updater for artifact downloads, checksum verification, and formula rendering
- refuse downgrades and prereleases, stop on API rate limiting, continue past missing/unparseable releases, and avoid no-op commits
- add manual targeted dry-runs plus unit/workflow security coverage and maintainer documentation
- reconcile newly discovered drift in clawscan (0.1.6) and slacrawl (0.8.3)

## Proof

- `python3 -m unittest discover -s tests -v` (40 tests)
- `python3 -m py_compile .github/scripts/reconcile_formulae.py .github/scripts/update_formula.py`
- `ruby -c Formula/*.rb`
- `brew style Formula/*.rb`
- live dry-run: all 15 formulae current after applying the two discovered updates; formula SHA-256 manifest unchanged
- scratch rollback: exactly one wacrawl drift detected and all four 0.3.7 assets downloaded and rehashed
- scratch forward version: downgrade to GitHub latest refused before updater invocation
- structured autoreview clean
