### PR TITLE
fix: correct Gitcrawl paths and shim guidance

### DIFF
--- a/Formula/gitcrawl.rb
+++ b/Formula/gitcrawl.rb
@@ -1,5 +1,5 @@
 class Gitcrawl < Formula
-  desc "Local GitHub issue and PR archive with gh-compatible caching"
+  desc "Local GitHub issue and PR archive, search, and clustering"
   homepage "https://github.com/openclaw/gitcrawl"
   version "0.9.3"
   license "MIT"
@@ -39,12 +39,24 @@ class Gitcrawl < Formula
 
   def caveats
     <<~EOS
-      gitcrawl stores local state under:
-        ~/.config/gitcrawl/
-        ~/.cache/gitcrawl/
+      gitcrawl fresh defaults:
+      macOS:
+        ~/Library/Application Support/gitcrawl/ (config, database, vectors, logs)
+        ~/Library/Caches/gitcrawl/ (cache)
+      Linux:
+        ${XDG_CONFIG_HOME:-~/.config}/gitcrawl/ (config)
+        ${XDG_DATA_HOME:-~/.local/share}/gitcrawl/ (database, vectors)
+        ${XDG_CACHE_HOME:-~/.cache}/gitcrawl/ (cache)
+        ${XDG_STATE_HOME:-~/.local/state}/gitcrawl/ (logs)
 
-      To use the GitHub CLI shim, symlink the same binary as gitcrawl-gh or gh
-      and set GITCRAWL_GH_PATH to the real GitHub CLI.
+      Absolute XDG overrides are honored on macOS too. Existing legacy paths
+      may still be reused; explicit or configured paths can differ.
+      See https://gitcrawl.sh/configuration/ for details.
+      Run gitcrawl doctor --json for active config and database paths.
+
+      Gitcrawl's gh compatibility shim has moved to Octopool.
+      Keep your existing gh/Octopool setup; do not symlink Gitcrawl as gh.
+      See https://gitcrawl.sh/gh-shim/ for migration details.
     EOS
   end
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install --cask openclaw/tap/<name>
 - `crabfleet` — Fleet management CLI for Crabbox workers
 - `crawlbar` — macOS menu bar control plane for local-first crawler CLIs
 - `discrawl` — Mirror Discord into SQLite and search server history locally
-- `gitcrawl` — Local GitHub issue and PR archive with gh-compatible caching
+- `gitcrawl` — Local GitHub issue and PR archive, search, and clustering
 - `gogcli` — Google CLI for Gmail, Calendar, Drive, Docs, Sheets, and more
 - `goplaces` — Modern Go client + CLI for the Google Places API (New)
 - `graincrawl` — Local-first Granola crawler into SQLite and Markdown
@@ -67,6 +67,11 @@ Formula updates have two paths. Source-repository release workflows dispatch `Up
 immediate updates. That workflow accepts a Homebrew formula token, a semantic release tag, and a
 GitHub repository in `owner/repo` form. Optional artifact inputs must resolve to HTTPS release
 assets and may use only the placeholders documented by the workflow.
+
+Existing `Formula/*.rb` files own each tool's caveats and install instructions. The updater
+preserves that content while changing release metadata, so maintain it here rather than in an
+upstream release workflow. For Gitcrawl, see the [configuration reference](https://gitcrawl.sh/configuration/)
+and [gh shim migration to Octopool](https://gitcrawl.sh/gh-shim/).
 
 `Reconcile Formulae` is the self-healing fallback. Every three hours it derives each source
 repository from the formula's GitHub `homepage`, compares the formula with that repository's latest

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import os
 import pathlib
+import re
 import tempfile
 import unittest
 from unittest import mock
@@ -18,6 +19,140 @@ SPEC.loader.exec_module(update_formula)
 
 
 class UpdateFormulaTest(unittest.TestCase):
+    def test_gitcrawl_description_matches_archive_search_and_clustering(self) -> None:
+        formula = (ROOT / "Formula" / "gitcrawl.rb").read_text()
+        description = re.search(r'^  desc "([^"]+)"$', formula, re.MULTILINE)
+        self.assertIsNotNone(description)
+        assert description is not None
+        text = description.group(1)
+        for keyword in ("local", "archive", "search", "cluster"):
+            with self.subTest(keyword=keyword):
+                self.assertIn(keyword, text.lower())
+        self.assertNotIn("gh-compatible", text.lower())
+        self.assertIn(f"- `gitcrawl` — {text}\n", (ROOT / "README.md").read_text())
+
+    def test_gitcrawl_caveats_document_platform_defaults_and_shim_ownership(self) -> None:
+        formula = (ROOT / "Formula" / "gitcrawl.rb").read_text()
+        caveats = formula.split("  def caveats\n", 1)[1].split("    EOS", 1)[0]
+        platform_paths = {
+            "macOS": {
+                "~/Library/Application Support/gitcrawl/": ("config", "database", "vectors", "logs"),
+                "~/Library/Caches/gitcrawl/": ("cache",),
+            },
+            "Linux": {
+                "${XDG_CONFIG_HOME:-~/.config}/gitcrawl/": ("config",),
+                "${XDG_DATA_HOME:-~/.local/share}/gitcrawl/": ("database", "vectors"),
+                "${XDG_CACHE_HOME:-~/.cache}/gitcrawl/": ("cache",),
+                "${XDG_STATE_HOME:-~/.local/state}/gitcrawl/": ("logs",),
+            },
+        }
+        for platform, paths in platform_paths.items():
+            with self.subTest(platform=platform):
+                section = re.search(rf"{platform}:\n((?:[ \t]{{8,}}[^\n]+\n)+)", caveats)
+                self.assertIsNotNone(section)
+                assert section is not None
+                for path, purposes in paths.items():
+                    line = next((line for line in section.group(1).splitlines() if path in line), "")
+                    self.assertTrue(line, f"missing {platform} default: {path}")
+                    for purpose in purposes:
+                        self.assertIn(purpose, line)
+
+        normalized = " ".join(caveats.lower().split())
+        for pattern in (
+            r"fresh.*defaults",
+            r"absolute xdg overrides.*macos",
+            r"legacy paths.*reused",
+            r"explicit.*configured paths.*differ",
+            r"gitcrawl doctor --json.*active config.*database paths",
+            r"gh compatibility shim.*moved to octopool",
+            r"keep.*existing gh/octopool setup",
+            r"do not symlink gitcrawl as gh",
+        ):
+            with self.subTest(pattern=pattern):
+                self.assertRegex(normalized, pattern)
+        for link in ("https://gitcrawl.sh/configuration/", "https://gitcrawl.sh/gh-shim/"):
+            with self.subTest(link=link):
+                self.assertIn(link, caveats)
+        for obsolete in ("GITCRAWL_GH_PATH", "gitcrawl-gh", "symlink the same binary", "ln -s"):
+            with self.subTest(obsolete=obsolete):
+                self.assertNotIn(obsolete, caveats)
+        doctor_guidance = re.search(r"gitcrawl doctor --json[^.]*\.", normalized)
+        self.assertIsNotNone(doctor_guidance)
+        assert doctor_guidance is not None
+        self.assertNotRegex(doctor_guidance.group(0), r"cache|vector|log")
+
+    def test_gitcrawl_release_updates_preserve_maintained_formula_content(self) -> None:
+        formula = (ROOT / "Formula" / "gitcrawl.rb").read_text()
+        version_match = re.search(r'^  version "(\d+)\.(\d+)\.(\d+)"$', formula, re.MULTILINE)
+        self.assertIsNotNone(version_match)
+        assert version_match is not None
+        major, minor, patch = version_match.groups()
+        version = f"{major}.{minor}.{int(patch) + 1}"
+        hashes = {target: str(index) * 64 for index, target in enumerate(update_formula.RELEASE_TARGETS, 1)}
+        old_pairs = {(match.group("url"), match.group("sha")) for match in update_formula.iter_url_sha_pairs(formula)}
+        metadata = r'(?m)^\s*(?:version|url|sha256) "[^"\n]+"$'
+
+        for mode in ("explicit-assets", "legacy-template", "verified-hashes"):
+            with self.subTest(mode=mode):
+                template = "{formula}_{version}_{target}.tar.gz"
+                if mode == "explicit-assets":
+                    template = "{formula}_{version}_custom_{target}.tar.gz"
+                assets = {
+                    target: {"name": template.format(formula="gitcrawl", version=version, target=target), "sha256": digest}
+                    for target, digest in hashes.items()
+                }
+                expected = {
+                    f"https://github.com/openclaw/gitcrawl/releases/download/v{version}/{asset['name']}": asset["sha256"]
+                    for asset in assets.values()
+                }
+                arguments = ["--formula", "gitcrawl", "--tag", f"v{version}", "--repository", "openclaw/gitcrawl"]
+                if mode == "explicit-assets":
+                    arguments += ["--assets-json", json.dumps(assets)]
+                else:
+                    arguments += ["--artifact-template", template]
+                if mode == "verified-hashes":
+                    for target, digest in hashes.items():
+                        arguments += [f"--{target.replace('_', '-')}-sha256", digest]
+                    arguments += [
+                        "--source-tag-object", "b" * 40,
+                        "--source-tag-commit", "a" * 40,
+                        "--request-id", "gitcrawl-caveats-regression",
+                    ]
+
+                previous_directory = pathlib.Path.cwd()
+                with tempfile.TemporaryDirectory() as directory:
+                    root = pathlib.Path(directory)
+                    (root / "Formula").mkdir()
+                    path = root / "Formula" / "gitcrawl.rb"
+                    path.write_text(formula)
+                    os.chdir(root)
+                    try:
+                        with (
+                            mock.patch.object(update_formula, "sha256", side_effect=expected.__getitem__) as download,
+                            mock.patch.object(update_formula, "verify_remote_source_tag") as verify_tag,
+                        ):
+                            self.assertEqual(update_formula.main(arguments), 0)
+                    finally:
+                        os.chdir(previous_directory)
+                    updated = path.read_text()
+
+                if mode == "verified-hashes":
+                    download.assert_not_called()
+                    verify_tag.assert_called_once_with("openclaw/gitcrawl", f"v{version}", "b" * 40, "a" * 40)
+                else:
+                    verify_tag.assert_not_called()
+                    self.assertCountEqual([call.args[0] for call in download.call_args_list], expected)
+                pairs = [
+                    (match.group("url").replace("#{version}", version), match.group("sha"))
+                    for match in update_formula.iter_url_sha_pairs(updated)
+                ]
+                self.assertCountEqual(pairs, expected.items())
+                self.assertTrue(set(pairs).isdisjoint(old_pairs))
+                self.assertIn(f'  version "{version}"', updated)
+                self.assertNotIn(version_match.group(0), updated)
+                # Only release metadata may change: preserve desc, install, caveats, and test verbatim.
+                self.assertEqual(re.sub(metadata, "", updated), re.sub(metadata, "", formula))
+
     def test_validates_dispatch_identifiers(self) -> None:
         self.assertEqual(update_formula.validate_tap_token("gogcli", "formula"), "gogcli")
         self.assertEqual(update_formula.validate_repository("openclaw/gogcli"), "openclaw/gogcli")


### PR DESCRIPTION
## Summary

Correct the stale Homebrew guidance observed in the [Gitcrawl v0.9.3 release](https://github.com/openclaw/gitcrawl/releases/tag/v0.9.3), specifically [the original formula lines 40–48](https://github.com/openclaw/homebrew-tap/blob/b87529d90daccdee10af999120359a12a667d009/Formula/gitcrawl.rb#L40-L48).

- Document fresh macOS Application Support/Caches locations and Linux XDG config/data/cache/state paths, with override and legacy-path qualifications and links to current Gitcrawl documentation.
- Remove the retired Gitcrawl shim setup advice and preserve an existing `gh`/Octopool setup. Neither `gh` nor `gitcrawl-gh` is a functioning Gitcrawl compatibility alias in v0.9.3.
- Align the formula/README descriptions with Gitcrawl's local archive, search, and clustering role; explain where maintained caveats belong.

## Ownership and regression protection

The shared release workflow delegates to this tap's updater. Existing `Formula/*.rb` files own their caveats and installation instructions; the updater changes release metadata while preserving that maintained content. The canonical formula is therefore the authoritative fix, without introducing a second template in Gitcrawl or the shared release workflow.

New tests read the actual Gitcrawl formula and exercise explicit-assets, legacy-template, and verified-hash update paths. They require release metadata to change while the description, installation logic, caveats, and formula test remain unchanged.

## Validation

- New content regressions failed against the original caveats and passed after the correction.
- All 44 Python tests passed: `python3 -m unittest discover -s tests -v`.
- Ruby syntax checks passed for all 15 formulae; the actual Ruby caveats method was rendered and checked.
- `git diff --check` passed, and Codex autoreview reported no actionable findings.
- Homebrew style is covered by repository CI; it was not bootstrapped locally.

The formula remains at **0.9.3**. Asset URLs, checksums, installation behavior, and existing formula test behavior are unchanged. This PR does not publish a Gitcrawl release or modify installed tools, shell configuration, or services.
