### PR TITLE
chore: update crabbox to 0.48.0

### DIFF
--- a/Formula/crabbox.rb
+++ b/Formula/crabbox.rb
@@ -9,8 +9,8 @@ class Crabbox < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/openclaw/crabbox/releases/download/v0.47.0/crabbox_0.47.0_darwin_amd64.tar.gz"
-      sha256 "642995363f7d6c367859e77f80eb66468ef2ed380d1e7ea4ae737f7deeb986d4"
+      url "https://github.com/openclaw/crabbox/releases/download/v0.48.0/crabbox_0.48.0_darwin_amd64.tar.gz"
+      sha256 "506da27cd230f89c75615f22fef6bb7cb7805d6bc9c3325b360ea4706c8a0573"
 
       define_method(:install) do
         bin.install "crabbox"
@@ -18,8 +18,8 @@ class Crabbox < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/openclaw/crabbox/releases/download/v0.47.0/crabbox_0.47.0_darwin_arm64.tar.gz"
-      sha256 "ef1567083f6bd0d01b2539efdd69ccd205c2642e7d9eefb073d58052e8a7bb91"
+      url "https://github.com/openclaw/crabbox/releases/download/v0.48.0/crabbox_0.48.0_darwin_arm64.tar.gz"
+      sha256 "d32f8eca889893e7b0c1a9ce7340baa9cfd6b34f115480e4cbfbdcbc1fc4b1cd"
 
       define_method(:install) do
         bin.install "crabbox"
@@ -30,16 +30,16 @@ class Crabbox < Formula
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
-      url "https://github.com/openclaw/crabbox/releases/download/v0.47.0/crabbox_0.47.0_linux_amd64.tar.gz"
-      sha256 "e513ba473be4eaaadf16f88fe030a03e6a11c0b49a088941fcccdbf3a09247ad"
+      url "https://github.com/openclaw/crabbox/releases/download/v0.48.0/crabbox_0.48.0_linux_amd64.tar.gz"
+      sha256 "73aaa82918b2bffdfdb75e2e82a3886fb53186c1b33335490bd88692efb14f94"
       define_method(:install) do
         bin.install "crabbox"
         bin.install "crabbox-apple-vm-helper" if OS.mac? && Hardware::CPU.arm?
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/openclaw/crabbox/releases/download/v0.47.0/crabbox_0.47.0_linux_arm64.tar.gz"
-      sha256 "94a388cd7301c7ba1d7e42d8c55d68c6b9dd55025e79cf247c58d659aa5039d4"
+      url "https://github.com/openclaw/crabbox/releases/download/v0.48.0/crabbox_0.48.0_linux_arm64.tar.gz"
+      sha256 "9f21faccd3a964c871b65434ca35df53e2ec144b6cc59c91e0ef737051f2dc1c"
       define_method(:install) do
         bin.install "crabbox"
         bin.install "crabbox-apple-vm-helper" if OS.mac? && Hardware::CPU.arm?


### PR DESCRIPTION
## Summary

Update Crabbox to [0.48.0](https://github.com/openclaw/crabbox/releases/tag/v0.48.0) using the exact formula emitted by its protected release renderer. The four Darwin/Linux architecture routes use hashes rechecked against fresh, unauthenticated downloads of the immutable public assets. The Apple Silicon helper installation and all other formula behavior are unchanged.

## Verification

- [Fresh public release verification](https://github.com/openclaw/crabbox/actions/runs/33423410938): both native static and execution jobs passed on Apple Silicon and Intel.
- Cold public-proxy-only Go installation passed: exact version 0.48.0, replacement-free module metadata, required JSON Schema fork, and both help surfaces.
- All eight public assets were downloaded again and matched their frozen IDs, sizes, and SHA-256 digests.
- Formula bytes exactly match the protected Crabbox renderer.
- 44 Python tests passed; Ruby syntax checks and Homebrew style passed.
- Independent blocking-priority review found no actionable findings.

After merge, the protected Crabbox Homebrew workflow will prove fresh native Apple Silicon and Intel installations against the public release and immutable verifier artifacts.
