### PR TITLE
fix: reserve Crabbox formula updates for verified releases

### DIFF
--- a/.github/scripts/reconcile_formulae.py
+++ b/.github/scripts/reconcile_formulae.py
@@ -331,6 +331,11 @@ def reconcile(
     summary = Summary()
     for path in formula_paths(root, selected):
         summary.scanned += 1
+        reason = update_formula.release_management_reason(path, root)
+        if reason:
+            summary.skipped += 1
+            print(f"SKIP {path.stem}: {reason}")
+            continue
         try:
             info = parse_formula(path)
         except (OSError, ValueError) as error:

--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -34,6 +34,22 @@ REQUEST_ID_PATTERN = re.compile(r"[A-Za-z0-9][-A-Za-z0-9._:]{0,127}")
 RELEASE_TARGETS = ("darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64")
 CANONICAL_TARGETS = frozenset(("darwin_universal", *RELEASE_TARGETS))
 TEMPLATE_FIELDS = frozenset(("formula", "version", "tag", "target"))
+RELEASE_MANAGED_FORMULAE = {
+    "crabbox": (
+        "release-managed; use Crabbox's release process and a normal tap PR after public native "
+        "and Go-install verification: https://github.com/openclaw/crabbox/blob/main/docs/RELEASING.md"
+    ),
+}
+
+
+def release_management_reason(path: pathlib.Path, root: pathlib.Path) -> str | None:
+    for formula, reason in RELEASE_MANAGED_FORMULAE.items():
+        managed = root / "Formula" / f"{formula}.rb"
+        if path.resolve() == managed.resolve() or (
+            path.exists() and managed.exists() and path.samefile(managed)
+        ):
+            return reason
+    return None
 
 
 def validate_tap_token(value: str, description: str) -> str:
@@ -1093,6 +1109,14 @@ def main(argv: list[str] | None = None) -> int:
     args.tag = validate_release_tag(args.tag)
     if args.cask:
         args.cask = validate_tap_token(args.cask, "cask")
+    if not args.verify_source_tag_only:
+        paths = [tap_path("Formula", args.formula)]
+        if args.cask:
+            paths.append(tap_path("Casks", args.cask))
+        for path in paths:
+            reason = release_management_reason(path, pathlib.Path.cwd())
+            if reason:
+                raise SystemExit(f"refusing generic update of {path}: {reason}")
     if args.macos_artifact:
         validate_artifact_token(args.macos_artifact, "macOS artifact")
     if args.linux_url:

--- a/README.md
+++ b/README.md
@@ -62,18 +62,34 @@ brew uninstall --cask --zap openclaw/tap/<name>
 
 ## Maintainers
 
-Formula updates have two paths. Source-repository release workflows dispatch `Update Formula` for
-immediate updates. That workflow accepts a Homebrew formula token, a semantic release tag, and a
+Most formula updates have two automated paths. Source-repository release workflows dispatch
+`Update Formula` for immediate updates. That workflow accepts a Homebrew formula token, a semantic release tag, and a
 GitHub repository in `owner/repo` form. Optional artifact inputs must resolve to HTTPS release
 assets and may use only the placeholders documented by the workflow.
+
+**Crabbox is release-managed and excluded from both automated update paths.** Reconciliation skips
+it before parsing or release lookup, including selected and dry-run scans. Generic `Update Formula`
+dispatches and updater CLI writes for Crabbox are retired: legacy, exact-assets, and complete
+`verified-hashes-v1` inputs all fail before source-tag checks, downloads, or formula/cask writes.
+There is no force or readiness override. The public read-only `--verify-source-tag-only` CLI check
+remains available with the complete verified-hash input set; it grants no update authority.
+
+Only the existing [Crabbox release process](https://github.com/openclaw/crabbox/blob/main/docs/RELEASING.md)
+owns that formula handoff. After fresh public native verification, proxy-only public Go-install
+proof, and verification of all four public archive hashes, the release operator uses the protected
+`render-homebrew-formula.mjs` renderer and submits its exact literal output through a normal tap PR.
+Native Homebrew installation proof follows the tap merge; waiting for that proof before updating
+the formula would deadlock. This is an explicit release handoff, not an automatic completion event
+or a trigger on publication. Crabbox still receives all ordinary tap validation. Automation,
+schedules, tokens, permissions, and update contracts for other formulae are unchanged.
 
 Existing `Formula/*.rb` files own each tool's caveats and install instructions. The updater
 preserves that content while changing release metadata, so maintain it here rather than in an
 upstream release workflow. For Gitcrawl, see the [configuration reference](https://gitcrawl.sh/configuration/)
 and [gh shim migration to Octopool](https://gitcrawl.sh/gh-shim/).
 
-`Reconcile Formulae` is the self-healing fallback. Every three hours it derives each source
-repository from the formula's GitHub `homepage`, compares the formula with that repository's latest
+`Reconcile Formulae` is the self-healing fallback for non-release-managed formulae. Every three hours
+it derives each source repository from the formula's GitHub `homepage`, compares the formula with that repository's latest
 stable published release, and runs the same updater and checksum-download logic when the release is
 newer. It never downgrades, skips drafts and prereleases, and makes no commit when every formula is
 current. Manual reconciles default to dry-run and can target one formula. The reconciler reads public

--- a/tests/test_reconcile_formulae.py
+++ b/tests/test_reconcile_formulae.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
+import os
 import pathlib
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -81,6 +85,75 @@ class ReconcileFormulaeTest(unittest.TestCase):
                 info = reconcile_formulae.parse_formula(path)
                 self.assertEqual(info.name, path.stem)
                 self.assertTrue(info.update_options)
+
+    def test_crabbox_skips_before_parsing_or_lookup_in_all_scan_modes(self) -> None:
+        for selected in (None, "crabbox"):
+            for dry_run in (False, True):
+                with self.subTest(selected=selected, dry_run=dry_run), tempfile.TemporaryDirectory() as directory:
+                    root = pathlib.Path(directory)
+                    (root / "Formula").mkdir()
+                    path = root / "Formula" / "crabbox.rb"
+                    path.write_text("not a parseable formula\n")
+                    before = path.read_bytes()
+                    output = io.StringIO()
+                    with (
+                        mock.patch.object(reconcile_formulae, "parse_formula") as parse,
+                        mock.patch.object(reconcile_formulae.update_formula, "sha256") as download,
+                        contextlib.redirect_stdout(output),
+                    ):
+                        lookup = mock.Mock()
+                        updater = mock.Mock()
+                        summary = reconcile_formulae.reconcile(root, selected, dry_run, lookup, updater)
+                    self.assertEqual(summary, reconcile_formulae.Summary(scanned=1, skipped=1))
+                    self.assertIn("SKIP crabbox:", output.getvalue())
+                    self.assertIn("release-managed", output.getvalue())
+                    self.assertIn("https://github.com/openclaw/crabbox/blob/main/docs/RELEASING.md", output.getvalue())
+                    for operation in (parse, lookup, updater, download):
+                        operation.assert_not_called()
+                    self.assertEqual(path.read_bytes(), before)
+
+    def test_crabbox_skip_still_updates_another_stale_formula(self) -> None:
+        directory, root = self.make_tap()
+        self.addCleanup(directory.cleanup)
+        crabbox = root / "Formula" / "crabbox.rb"
+        crabbox.write_bytes((ROOT / "Formula" / "crabbox.rb").read_bytes())
+        before = crabbox.read_bytes()
+        lookup = mock.Mock(return_value=reconcile_formulae.Release("v1.2.4", False, False))
+
+        def updater(root: pathlib.Path, info: reconcile_formulae.FormulaInfo, tag: str, dry_run: bool) -> None:
+            self.assertFalse(dry_run)
+            previous_directory = pathlib.Path.cwd()
+            os.chdir(root)
+            try:
+                reconcile_formulae.update_formula.main([
+                    "--formula", info.name, "--tag", tag, "--repository", info.repository, *info.update_options,
+                ])
+            finally:
+                os.chdir(previous_directory)
+
+        with mock.patch.object(reconcile_formulae.update_formula, "sha256", return_value="e" * 64) as download:
+            summary = reconcile_formulae.reconcile(root, None, False, lookup, updater)
+        self.assertEqual(summary, reconcile_formulae.Summary(scanned=2, skipped=1, drift=1, updated=1))
+        lookup.assert_called_once_with("openclaw/example")
+        self.assertEqual(download.call_count, 4)
+        updated = (root / "Formula" / "example.rb").read_text()
+        self.assertIn('version "1.2.4"', updated)
+        self.assertEqual(updated.count('sha256 "' + "e" * 64 + '"'), 4)
+        self.assertEqual(crabbox.read_bytes(), before)
+
+    def test_crabbox_symlink_alias_is_skipped_before_parsing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "Formula").mkdir()
+            (root / "Formula" / "crabbox.rb").write_text("not a parseable formula\n")
+            (root / "Formula" / "example.rb").symlink_to("crabbox.rb")
+            with mock.patch.object(reconcile_formulae, "parse_formula") as parse:
+                lookup = mock.Mock()
+                updater = mock.Mock()
+                summary = reconcile_formulae.reconcile(root, "example", True, lookup, updater)
+            self.assertEqual(summary, reconcile_formulae.Summary(scanned=1, skipped=1))
+            for operation in (parse, lookup, updater):
+                operation.assert_not_called()
 
     def test_no_drift_does_not_run_updater_or_change_formula(self) -> None:
         directory, root = self.make_tap()

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -18,7 +18,169 @@ update_formula = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(update_formula)
 
 
+def platform_install_formula() -> str:
+    lines = [
+        "class Example < Formula",
+        '  desc "Example CLI"',
+        '  homepage "https://github.com/openclaw/example"',
+        '  license "MIT"',
+    ]
+    for platform, target_os in (("macos", "darwin"), ("linux", "linux")):
+        lines.append(f"  on_{platform} do")
+        for cpu, arch in (("intel", "amd64"), ("arm", "arm64")):
+            lines.extend([
+                f"    if Hardware::CPU.{cpu}?",
+                f'      url "https://github.com/openclaw/example/releases/download/v0.43.0/'
+                f'example_0.43.0_{target_os}_{arch}.tar.gz"',
+                f'      sha256 "{"a" * 64}"',
+                "      define_method(:install) do",
+                '        bin.install "example"',
+                '        bin.install "example-helper" if OS.mac? && Hardware::CPU.arm?',
+                "      end",
+                "    end",
+            ])
+        lines.append("  end")
+    return "\n".join([*lines, "  test do", '    system bin/"example", "--version"', "  end", "end", ""])
+
+
+def crabbox_arguments(mode: str) -> list[str]:
+    arguments = ["--formula", "crabbox", "--tag", "v1.2.3", "--repository", "openclaw/crabbox"]
+    if mode == "explicit-assets":
+        assets = {
+            target: {"name": f"crabbox_1.2.3_{target}.tar.gz", "sha256": "e" * 64}
+            for target in update_formula.RELEASE_TARGETS
+        }
+        arguments += ["--assets-json", json.dumps(assets)]
+    elif mode in ("legacy-template", "verified-hashes"):
+        arguments += ["--artifact-template", "{formula}_{version}_{target}.tar.gz"]
+    elif mode == "legacy-url":
+        arguments += ["--artifact-url", "https://example.test/{formula}_{version}.tar.gz"]
+    if mode == "verified-hashes":
+        for target in update_formula.RELEASE_TARGETS:
+            arguments += [f"--{target.replace('_', '-')}-sha256", "e" * 64]
+        arguments += [
+            "--source-tag-object", "b" * 40,
+            "--source-tag-commit", "a" * 40,
+            "--request-id", "crabbox-readiness-regression",
+        ]
+    return arguments
+
+
 class UpdateFormulaTest(unittest.TestCase):
+    def assert_release_managed_rejection(self, root: pathlib.Path, arguments: list[str]) -> None:
+        before = {path.relative_to(root): path.read_bytes() for path in root.rglob("*") if path.is_file()}
+        previous_directory = pathlib.Path.cwd()
+        os.chdir(root)
+        try:
+            with (
+                mock.patch.multiple(
+                    update_formula,
+                    sha256=mock.DEFAULT,
+                    verify_remote_source_tag=mock.DEFAULT,
+                    seed_formula=mock.DEFAULT,
+                    update_cask=mock.DEFAULT,
+                ) as operations,
+                mock.patch.object(update_formula.urllib.request, "urlopen") as network,
+                mock.patch.object(update_formula.subprocess, "run") as process,
+                mock.patch.object(pathlib.Path, "write_text") as write,
+            ):
+                for operation in (*operations.values(), network, process, write):
+                    operation.side_effect = AssertionError("side effect before release-management rejection")
+                with self.assertRaisesRegex(SystemExit, "release-managed.*docs/RELEASING.md"):
+                    update_formula.main(arguments)
+                for operation in (*operations.values(), network, process, write):
+                    operation.assert_not_called()
+        finally:
+            os.chdir(previous_directory)
+        self.assertEqual(
+            {path.relative_to(root): path.read_bytes() for path in root.rglob("*") if path.is_file()}, before
+        )
+
+    def test_crabbox_rejects_every_generic_write_before_side_effects(self) -> None:
+        for mode in ("legacy", "legacy-template", "legacy-url", "explicit-assets", "verified-hashes"):
+            for existing in (False, True):
+                for cask in (False, True):
+                    with self.subTest(mode=mode, existing=existing, cask=cask), tempfile.TemporaryDirectory() as directory:
+                        root = pathlib.Path(directory)
+                        (root / "Formula").mkdir()
+                        (root / "Casks").mkdir()
+                        if existing:
+                            (root / "Formula" / "crabbox.rb").write_bytes((ROOT / "Formula" / "crabbox.rb").read_bytes())
+                            (root / "Casks" / "example.rb").write_text('cask "example" do\nend\n')
+                        arguments = crabbox_arguments(mode)
+                        if cask:
+                            arguments += ["--cask", "example", "--cask-artifact", "example-{version}.zip"]
+                        self.assert_release_managed_rejection(root, arguments)
+
+    def test_crabbox_path_aliases_cannot_bypass_generic_write_gate(self) -> None:
+        for mode in ("legacy", "explicit-assets", "verified-hashes"):
+            for alias in ("symlink", "dangling-symlink", "hardlink", "cask-directory"):
+                with self.subTest(mode=mode, alias=alias), tempfile.TemporaryDirectory() as directory:
+                    root = pathlib.Path(directory)
+                    (root / "Formula").mkdir()
+                    managed = root / "Formula" / "crabbox.rb"
+                    if alias != "dangling-symlink":
+                        managed.write_bytes((ROOT / "Formula" / "crabbox.rb").read_bytes())
+                    path = root / "Formula" / "example.rb"
+                    arguments = crabbox_arguments(mode)
+                    arguments[1] = "example"
+                    if alias == "hardlink":
+                        path.hardlink_to(managed)
+                    elif alias == "cask-directory":
+                        path.write_text(platform_install_formula())
+                        (root / "Casks").symlink_to("Formula", target_is_directory=True)
+                        arguments += ["--cask", "crabbox", "--cask-artifact", "example.zip"]
+                    else:
+                        path.symlink_to("crabbox.rb")
+                    self.assert_release_managed_rejection(root, arguments)
+
+    def test_crabbox_complete_verify_only_is_read_only_even_without_formula(self) -> None:
+        for existing in (False, True):
+            with self.subTest(existing=existing), tempfile.TemporaryDirectory() as directory:
+                root = pathlib.Path(directory)
+                if existing:
+                    (root / "Formula").mkdir()
+                    (root / "Formula" / "crabbox.rb").write_bytes((ROOT / "Formula" / "crabbox.rb").read_bytes())
+                before = sorted(root.rglob("*"))
+                previous_directory = pathlib.Path.cwd()
+                os.chdir(root)
+                try:
+                    with (
+                        mock.patch.object(update_formula, "verify_remote_source_tag") as verify_tag,
+                        mock.patch.object(update_formula, "sha256") as download,
+                        mock.patch.object(update_formula, "seed_formula") as seed,
+                        mock.patch.object(update_formula, "update_cask") as cask,
+                        mock.patch.object(pathlib.Path, "write_text") as write,
+                    ):
+                        self.assertEqual(update_formula.main(crabbox_arguments("verified-hashes") + ["--verify-source-tag-only"]), 0)
+                        verify_tag.assert_called_once_with("openclaw/crabbox", "v1.2.3", "b" * 40, "a" * 40)
+                        for operation in (download, seed, cask, write):
+                            operation.assert_not_called()
+                finally:
+                    os.chdir(previous_directory)
+                self.assertEqual(sorted(root.rglob("*")), before)
+                if existing:
+                    self.assertEqual((root / "Formula" / "crabbox.rb").read_bytes(), (ROOT / "Formula" / "crabbox.rb").read_bytes())
+
+    def test_crabbox_legacy_and_partial_verify_only_fail_before_tag_lookup(self) -> None:
+        for extra in ([], ["--darwin-amd64-sha256", "e" * 64]):
+            with self.subTest(extra=extra), tempfile.TemporaryDirectory() as directory:
+                root = pathlib.Path(directory)
+                previous_directory = pathlib.Path.cwd()
+                os.chdir(root)
+                try:
+                    with (
+                        mock.patch.object(update_formula, "verify_remote_source_tag") as verify_tag,
+                        mock.patch.object(update_formula, "sha256") as download,
+                        self.assertRaisesRegex(SystemExit, "requires.*(?:complete|all inputs)"),
+                    ):
+                        update_formula.main(crabbox_arguments("legacy") + extra + ["--verify-source-tag-only"])
+                    verify_tag.assert_not_called()
+                    download.assert_not_called()
+                finally:
+                    os.chdir(previous_directory)
+                self.assertEqual(list(root.iterdir()), [])
+
     def test_gitcrawl_description_matches_archive_search_and_clustering(self) -> None:
         formula = (ROOT / "Formula" / "gitcrawl.rb").read_text()
         description = re.search(r'^  desc "([^"]+)"$', formula, re.MULTILINE)
@@ -160,6 +322,8 @@ class UpdateFormulaTest(unittest.TestCase):
 
         invalid_values = (
             (update_formula.validate_tap_token, ("../../README", "formula")),
+            (update_formula.validate_tap_token, ("Crabbox", "formula")),
+            (update_formula.validate_tap_token, ("./crabbox", "formula")),
             (update_formula.validate_repository, ("openclaw/gogcli/extra",)),
             (update_formula.validate_release_tag, ('v1.2.3"\nsystem("id")',)),
         )
@@ -538,7 +702,7 @@ end
             self.assertEqual(updated.count(digest), 1)
 
     def test_verified_hash_mode_preserves_formula_specific_install_blocks(self) -> None:
-        formula = (ROOT / "Formula" / "crabbox.rb").read_text()
+        formula = platform_install_formula()
         hashes = {
             "darwin_amd64": "1" * 64,
             "darwin_arm64": "2" * 64,
@@ -548,9 +712,9 @@ end
 
         updated = update_formula.render_verified_target_formula(
             formula,
-            "openclaw/crabbox",
+            "openclaw/example",
             "v0.36.1",
-            "crabbox",
+            "example",
             "0.36.1",
             "{formula}_{version}_{target}.tar.gz",
             {},
@@ -559,14 +723,14 @@ end
 
         self.assertNotRegex(updated, r"(?m)^\s*version(?:\s|$)")
         self.assertEqual(updated.count("define_method(:install) do"), 4)
-        self.assertEqual(updated.count('bin.install "crabbox"'), 4)
-        self.assertEqual(updated.count('bin.install "crabbox-apple-vm-helper"'), 4)
+        self.assertEqual(updated.count('bin.install "example"'), 4)
+        self.assertEqual(updated.count('bin.install "example-helper"'), 4)
         for target, digest in hashes.items():
-            self.assertIn(f"crabbox_#{{version}}_{target}.tar.gz", updated)
+            self.assertIn(f"example_#{{version}}_{target}.tar.gz", updated)
             self.assertEqual(updated.count(digest), 1)
 
     def test_verified_hash_mode_rejects_duplicate_or_mismatched_version_lines(self) -> None:
-        formula = (ROOT / "Formula" / "crabbox.rb").read_text()
+        formula = platform_install_formula()
         hashes = {
             "darwin_amd64": "1" * 64,
             "darwin_arm64": "2" * 64,
@@ -590,9 +754,9 @@ end
             with self.subTest(description=description), self.assertRaisesRegex(SystemExit, message):
                 update_formula.render_verified_target_formula(
                     candidate,
-                    "openclaw/crabbox",
+                    "openclaw/example",
                     "v0.43.1",
-                    "crabbox",
+                    "example",
                     "0.43.1",
                     "{formula}_{version}_{target}.tar.gz",
                     {},

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 import pathlib
 import re
 import subprocess
+import sys
 import tempfile
 import textwrap
 import unittest
@@ -190,6 +192,72 @@ class WorkflowSecurityTest(unittest.TestCase):
         self.assertIn("python3 -m unittest discover -s tests -v", push_step)
         self.assertIn("brew style Formula/*.rb", push_step)
         self.assertIn('git push origin "HEAD:refs/heads/${DEFAULT_BRANCH}"', push_step)
+
+    def test_crabbox_policy_rejection_stops_workflow_before_commit_or_push(self) -> None:
+        workflow = UPDATE_WORKFLOW.read_text()
+        update = named_step_run(workflow, "Update formula")
+        push = named_step_run(workflow, "Commit and push")
+        for mode in ("legacy", "explicit-assets", "verified-hashes"):
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as directory:
+                root = pathlib.Path(directory)
+                scripts = root / ".github" / "scripts"
+                scripts.mkdir(parents=True)
+                (scripts / "update_formula.py").write_bytes((ROOT / ".github" / "scripts" / "update_formula.py").read_bytes())
+                (root / "Formula").mkdir()
+                formula = root / "Formula" / "crabbox.rb"
+                formula.write_bytes((ROOT / "Formula" / "crabbox.rb").read_bytes())
+                wrapper = root / "mock-updater.py"
+                wrapper.write_text('''import runpy
+import sys
+from unittest import mock
+sys.argv = sys.argv[1:]
+with mock.patch("urllib.request.urlopen", side_effect=AssertionError("network attempted")), \\
+     mock.patch("subprocess.run", side_effect=AssertionError("source tag lookup attempted")):
+    runpy.run_path(sys.argv[0], run_name="__main__")
+''')
+                harness = f'''git() {{ printf '%s\\n' "$*" >> "$GIT_CALLS"; }}
+                gh() {{ printf '%s\\n' "$*" >> "$GIT_CALLS"; }}
+                python3() {{ "$PYTHON" "$WRAPPER" "$@"; }}
+                {update}
+                {push}
+                '''
+                environment = dict.fromkeys((
+                    "ARTIFACT_TEMPLATE", "ARTIFACT_URL", "ASSETS_JSON", "CASK", "CASK_ARTIFACT",
+                    "DARWIN_AMD64_SHA256", "DARWIN_ARM64_SHA256", "DESCRIPTION", "LINUX_AMD64_SHA256",
+                    "LINUX_ARM64_SHA256", "LINUX_URL", "MACOS_ARTIFACT", "REQUEST_ID",
+                    "SOURCE_TAG_COMMIT", "SOURCE_TAG_OBJECT", "TARGET_ALIASES",
+                ), "")
+                environment.update({
+                    "PATH": os.defpath,
+                    "FORMULA": "crabbox",
+                    "TAG": "v1.2.3",
+                    "REPOSITORY": "openclaw/crabbox",
+                    "GIT_CALLS": str(root / "git-calls"),
+                    "PYTHON": sys.executable,
+                    "WRAPPER": str(wrapper),
+                })
+                targets = ("darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64")
+                if mode == "explicit-assets":
+                    environment["ASSETS_JSON"] = json.dumps({
+                        target: {"name": f"crabbox_1.2.3_{target}.tar.gz", "sha256": "e" * 64}
+                        for target in targets
+                    })
+                if mode == "verified-hashes":
+                    environment.update({target.upper() + "_SHA256": "e" * 64 for target in targets})
+                    environment.update({
+                        "ARTIFACT_TEMPLATE": "{formula}_{version}_{target}.tar.gz",
+                        "SOURCE_TAG_COMMIT": "a" * 40,
+                        "SOURCE_TAG_OBJECT": "b" * 40,
+                        "REQUEST_ID": "crabbox-policy-regression",
+                    })
+                completed = subprocess.run(
+                    ["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", harness],
+                    cwd=root, env=environment, check=False, capture_output=True, text=True,
+                )
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn("release-managed", completed.stderr)
+                self.assertFalse((root / "git-calls").exists())
+                self.assertEqual(formula.read_bytes(), (ROOT / "Formula" / "crabbox.rb").read_bytes())
 
     def test_push_retries_after_main_advances(self) -> None:
         script = named_step_run(UPDATE_WORKFLOW.read_text(), "Commit and push")


### PR DESCRIPTION
## Why

The publication-driven reconciler can update Crabbox's Homebrew formula as soon as a stable GitHub release appears, before the release owner has finished verifying the public native artifacts and public Go installation. Publication is not a readiness signal for this handoff. Generic updater dispatches expose the same premature-write path.

## Change

Reserve Crabbox formula mutations for the existing release-owner process. A shared release-management policy recognizes Crabbox and file aliases. Reconciliation skips it before parsing or release lookups in full, selected, and dry-run scans. The generic updater rejects Crabbox mutations before source-tag checks, downloads, seeding, or formula/cask writes, including legacy, exact-assets, and complete verified-hash inputs.

This intentionally retires generic Crabbox mutations. The complete public read-only `--verify-source-tag-only` checker remains available and grants no write authority. Other formula automation stays active; its schedules, workflows, permissions, and update contracts are unchanged.

The README records the explicit handoff: fresh public native verification, proxy-only public Go-install proof, and all four verified public archive hashes; then the protected renderer's exact literal output through a normal tap PR. Final native Homebrew installation proof follows that formula PR's merge to avoid a circular gate. There is no automatic completion event, publication trigger, or new force/readiness flag.

## Verification

- Original base: 44 unit tests passed.
- New regressions against the base scripts: expected red, 52 tests with 41 failed subcases and no errors.
- Final candidate: 52 unit tests passed. Coverage includes all mutation modes, absent formulas, file aliases, read-only verification, a mixed scan that still updates another formula, and workflow-shell rejection before commit/push.
- All 15 formula Ruby syntax checks passed; Crabbox-only Homebrew style passed.
- The local all-formula `brew style Formula/*.rb` check is **not green**: base and candidate produce byte-identical logs with 47 existing offenses, involving generic formula comments and duplicate method locations in the installed tap. An explicit `--formula` attempt did not resolve this. No unrelated formulas, cops, or CI configuration were changed to hide the baseline problem.
- [Hosted CI run 33587880102](https://github.com/openclaw/homebrew-tap/actions/runs/33587880102) **passed** against head `11e197c9386965bed41d4581185770845d35f9e5`: updater tests, all formula syntax checks, and full Homebrew style. The local style failure did not reproduce on the clean hosted runner. CodeQL checks also passed.
- Isolated Codex autoreview completed scoped-clean with no actionable P0-P2 findings. The approved candidate is unchanged since review.

This PR changes only the two automation scripts, README, and three test files. There is no formula/cask bump, workflow change, changelog change, or release publication. `Formula/crabbox.rb` remains unchanged (SHA-256 `d87296450b8280e83879df8f7cca7cf296d6d421ba9e1b004c8360164263f5bf`). The Crabbox release remains paused while this gate is prepared; Crabbox source and release artifacts are untouched. This PR is for CI and parent review, not automatic merge.
