### PR TITLE
chore(axorc): update to 0.1.9

### DIFF
--- a/Formula/axorc.rb
+++ b/Formula/axorc.rb
@@ -1,8 +1,8 @@
 class Axorc < Formula
   desc "Inspect and automate macOS Accessibility from the shell"
   homepage "https://github.com/openclaw/AXorcist"
-  url "https://github.com/openclaw/AXorcist/releases/download/v0.1.8/axorc-0.1.8-macos-universal.zip"
-  sha256 "40e05ecfcfc5d6b1b7d96649b2a3eb7a916e4bf584e91d1535238eee5f3e75e4"
+  url "https://github.com/openclaw/AXorcist/releases/download/v0.1.9/axorc-0.1.9-macos-universal.zip"
+  sha256 "80f6d6faf5b753e54282abc6158a3c2f52a13dcb72b8f055e917b85d2a918852"
   license "MIT"
 
   depends_on macos: :sonoma


### PR DESCRIPTION
## Summary

Update axorc from 0.1.8 to the published [AXorcist 0.1.9 release](https://github.com/openclaw/AXorcist/releases/tag/v0.1.9). Only the archive URL and checksum change; install behavior and signature tests are unchanged.

The signed release tag resolves to `37d7ae82ff1443b4b36344ca6f3bf0ad33f13b12`. The universal archive SHA256 is `80f6d6faf5b753e54282abc6158a3c2f52a13dcb72b8f055e917b85d2a918852`. The published archive was downloaded and verified for checksum, executable mode, Foundation Developer ID signature, online notarization, exact version, and help output.

## Validation

- Generated with the upstream formula renderer.
- Ruby syntax, Homebrew style, all 52 existing tap tests, and `git diff --check` passed.
- Scoped Codex P0 autoreview passed with no findings.

No installation or GUI automation was performed during formula preparation. Fresh-VM qualification was explicitly deferred for this expedited release; it is not claimed as passed.
