### PR TITLE
fix: time out stalled formula asset downloads

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -26,7 +26,6 @@ import urllib.request
 
 USER_AGENT = "steipete-homebrew-tap-updater"
 DOWNLOAD_TIMEOUT_SECONDS = 30
-DOWNLOAD_MAX_BYTES = 256 * 1024 * 1024
 TAP_TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9+@._-]*")
 REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9][A-Za-z0-9_.-]*")
 RELEASE_TAG_PATTERN = re.compile(r"v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?")
@@ -188,13 +187,9 @@ def sha256(url: str) -> str:
     validate_url(url, "download URL")
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     digest = hashlib.sha256()
-    total = 0
     try:
         with urllib.request.urlopen(request, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
             while chunk := response.read(1024 * 1024):
-                total += len(chunk)
-                if total > DOWNLOAD_MAX_BYTES:
-                    raise SystemExit(f"download of {url} exceeded the {DOWNLOAD_MAX_BYTES}-byte cap")
                 digest.update(chunk)
     except TimeoutError as error:
         raise SystemExit(f"timed out downloading {url} after {DOWNLOAD_TIMEOUT_SECONDS}s") from error

--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -19,11 +19,14 @@ import string
 import subprocess
 import sys
 import tempfile
+import urllib.error
 import urllib.parse
 import urllib.request
 
 
 USER_AGENT = "steipete-homebrew-tap-updater"
+DOWNLOAD_TIMEOUT_SECONDS = 30
+DOWNLOAD_MAX_BYTES = 256 * 1024 * 1024
 TAP_TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9+@._-]*")
 REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9][A-Za-z0-9_.-]*")
 RELEASE_TAG_PATTERN = re.compile(r"v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?")
@@ -185,9 +188,20 @@ def sha256(url: str) -> str:
     validate_url(url, "download URL")
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     digest = hashlib.sha256()
-    with urllib.request.urlopen(request) as response:
-        while chunk := response.read(1024 * 1024):
-            digest.update(chunk)
+    total = 0
+    try:
+        with urllib.request.urlopen(request, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
+            while chunk := response.read(1024 * 1024):
+                total += len(chunk)
+                if total > DOWNLOAD_MAX_BYTES:
+                    raise SystemExit(f"download of {url} exceeded the {DOWNLOAD_MAX_BYTES}-byte cap")
+                digest.update(chunk)
+    except TimeoutError as error:
+        raise SystemExit(f"timed out downloading {url} after {DOWNLOAD_TIMEOUT_SECONDS}s") from error
+    except urllib.error.URLError as error:
+        if isinstance(error.reason, TimeoutError):
+            raise SystemExit(f"timed out downloading {url} after {DOWNLOAD_TIMEOUT_SECONDS}s") from error
+        raise
     return digest.hexdigest()
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 - Update the `goplaces` cask to 0.4.9 with the `--radius` alias and signed, notarized macOS binaries.
+- Fail stalled formula and cask downloads with a 30-second socket timeout; thanks @SebTardif.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ brew uninstall --cask --zap openclaw/tap/<name>
 Formula updates have two automated paths. Source-repository release workflows dispatch
 `Update Formula` for immediate updates. That workflow accepts a Homebrew formula token, a semantic release tag, and a
 GitHub repository in `owner/repo` form. Optional artifact inputs must resolve to HTTPS release
-assets and may use only the placeholders documented by the workflow.
+assets and may use only the placeholders documented by the workflow. Downloads use a 30-second
+socket inactivity timeout and stream archive bytes without imposing a size limit. This timeout
+bounds stalled socket operations, not the total duration of a progressing download.
 
 **Crabbox uses the ordinary four-target `assets` handoff after publication.** The
 [Crabbox release process](https://github.com/openclaw/crabbox/blob/main/docs/RELEASING.md)

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -1175,9 +1175,8 @@ end
 
     def test_sha256_download_budget_is_documented(self) -> None:
         self.assertEqual(update_formula.DOWNLOAD_TIMEOUT_SECONDS, 30)
-        self.assertEqual(update_formula.DOWNLOAD_MAX_BYTES, 256 * 1024 * 1024)
 
-    def test_sha256_passes_timeout_and_hashes_a_bounded_body(self) -> None:
+    def test_sha256_passes_timeout_and_hashes_the_body(self) -> None:
         payload = b"formula-asset"
         url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
         with mock.patch.object(
@@ -1190,33 +1189,6 @@ end
         network.assert_called_once()
         self.assertEqual(network.call_args.args[0].full_url, url)
         self.assertEqual(network.call_args.kwargs["timeout"], update_formula.DOWNLOAD_TIMEOUT_SECONDS)
-
-    def test_sha256_rejects_bodies_over_the_documented_cap(self) -> None:
-        url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
-        with (
-            mock.patch.object(update_formula, "DOWNLOAD_MAX_BYTES", 16),
-            mock.patch.object(
-                update_formula.urllib.request,
-                "urlopen",
-                return_value=io.BytesIO(b"x" * 17),
-            ),
-            self.assertRaisesRegex(SystemExit, r"exceeded the 16-byte cap"),
-        ):
-            update_formula.sha256(url)
-
-    def test_sha256_hashes_a_body_at_the_documented_cap(self) -> None:
-        payload = b"x" * 16
-        url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
-        with (
-            mock.patch.object(update_formula, "DOWNLOAD_MAX_BYTES", 16),
-            mock.patch.object(
-                update_formula.urllib.request,
-                "urlopen",
-                return_value=io.BytesIO(payload),
-            ),
-        ):
-            digest = update_formula.sha256(url)
-        self.assertEqual(digest, hashlib.sha256(payload).hexdigest())
 
     def test_sha256_timeout_fails_closed(self) -> None:
         url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -169,7 +169,7 @@ class UpdateFormulaTest(unittest.TestCase):
                     for current in (False, True):
                         before = path.read_bytes()
 
-                        def download(request):
+                        def download(request, **_kwargs):
                             self.assertEqual(path.read_bytes(), before)
                             return io.BytesIO(urls[request.full_url])
 
@@ -208,7 +208,7 @@ class UpdateFormulaTest(unittest.TestCase):
                             "--assets-json", json.dumps(assets), "--cask", "example", "--cask-artifact", "example.zip",
                         ]
 
-                        def download(request):
+                        def download(request, **_kwargs):
                             self.assertEqual({p.relative_to(root): p.read_bytes() for p in root.rglob("*.rb")}, before)
                             target = next(t for t, item in assets.items() if request.full_url.endswith(item["name"]))
                             if target == "linux_arm64":
@@ -241,7 +241,7 @@ class UpdateFormulaTest(unittest.TestCase):
             (root / "Formula").mkdir()
             path = root / "Formula" / "crabbox.rb"
 
-            def download(request):
+            def download(request, **_kwargs):
                 self.assertFalse(path.exists())
                 target = next(t for t, item in crabbox_assets().items() if request.full_url.endswith(item["name"]))
                 return io.BytesIO(target.encode())
@@ -1172,6 +1172,75 @@ end
         self.assertIn('version "0.27.0"', updated)
         self.assertIn('sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"', updated)
         self.assertIn("CodexBar-macos-universal-#{version}.zip", updated)
+
+    def test_sha256_download_budget_is_documented(self) -> None:
+        self.assertEqual(update_formula.DOWNLOAD_TIMEOUT_SECONDS, 30)
+        self.assertEqual(update_formula.DOWNLOAD_MAX_BYTES, 256 * 1024 * 1024)
+
+    def test_sha256_passes_timeout_and_hashes_a_bounded_body(self) -> None:
+        payload = b"formula-asset"
+        url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
+        with mock.patch.object(
+            update_formula.urllib.request,
+            "urlopen",
+            return_value=io.BytesIO(payload),
+        ) as network:
+            digest = update_formula.sha256(url)
+        self.assertEqual(digest, hashlib.sha256(payload).hexdigest())
+        network.assert_called_once()
+        self.assertEqual(network.call_args.args[0].full_url, url)
+        self.assertEqual(network.call_args.kwargs["timeout"], update_formula.DOWNLOAD_TIMEOUT_SECONDS)
+
+    def test_sha256_rejects_bodies_over_the_documented_cap(self) -> None:
+        url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
+        with (
+            mock.patch.object(update_formula, "DOWNLOAD_MAX_BYTES", 16),
+            mock.patch.object(
+                update_formula.urllib.request,
+                "urlopen",
+                return_value=io.BytesIO(b"x" * 17),
+            ),
+            self.assertRaisesRegex(SystemExit, r"exceeded the 16-byte cap"),
+        ):
+            update_formula.sha256(url)
+
+    def test_sha256_hashes_a_body_at_the_documented_cap(self) -> None:
+        payload = b"x" * 16
+        url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
+        with (
+            mock.patch.object(update_formula, "DOWNLOAD_MAX_BYTES", 16),
+            mock.patch.object(
+                update_formula.urllib.request,
+                "urlopen",
+                return_value=io.BytesIO(payload),
+            ),
+        ):
+            digest = update_formula.sha256(url)
+        self.assertEqual(digest, hashlib.sha256(payload).hexdigest())
+
+    def test_sha256_timeout_fails_closed(self) -> None:
+        url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
+        with (
+            mock.patch.object(
+                update_formula.urllib.request,
+                "urlopen",
+                side_effect=TimeoutError("timed out"),
+            ),
+            self.assertRaisesRegex(SystemExit, r"timed out downloading .* after 30s"),
+        ):
+            update_formula.sha256(url)
+
+    def test_sha256_urlerror_timeout_fails_closed(self) -> None:
+        url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
+        with (
+            mock.patch.object(
+                update_formula.urllib.request,
+                "urlopen",
+                side_effect=urllib.error.URLError(TimeoutError("timed out")),
+            ),
+            self.assertRaisesRegex(SystemExit, r"timed out downloading .* after 30s"),
+        ):
+            update_formula.sha256(url)
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -233,7 +233,7 @@ import sys
 import urllib.error
 from unittest import mock
 sys.argv = sys.argv[1:]
-def download(request):
+def download(request, **_kwargs):
     url = request.full_url
     targets = ("darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64")
     urls = {f"https://github.com/openclaw/crabbox/releases/download/v1.2.3/crabbox_1.2.3_{t}.tar.gz": t for t in targets}


### PR DESCRIPTION
Formula and cask archive downloads could block indefinitely when the remote socket stopped responding. The shared checksum helper now uses a 30-second socket inactivity timeout and reports timeout failures clearly, matching the reconciler's existing API timeout.

Downloads continue to stream in 1 MiB chunks with no new archive-size restriction. This is a socket timeout, not a total elapsed-time deadline for progressing transfers.

Validation on macOS: all 58 Python tests passed. A real local HTTPS server with certificate verification enabled served a small payload and a 257 MiB stream; both produced the expected SHA-256. A response that stopped sending data failed after 30.01 seconds with the timeout diagnostic. No archive was written to disk. Ruby syntax and Homebrew style checks passed for the unchanged formula inventory.

Maintainer follow-up preserves the contributor's timeout fix, removes the proposed universal size cap, and adds documentation and a changelog entry thanking @SebTardif.
