### PR TITLE
fix: keep reconcile scanning after a bad artifact template

### DIFF
--- a/.github/scripts/reconcile_formulae.py
+++ b/.github/scripts/reconcile_formulae.py
@@ -219,19 +219,24 @@ def parse_formula(path: pathlib.Path) -> FormulaInfo:
         raise ValueError(f"formula version {explicit_version!r} does not match release tag {current_tag!r}")
     version_text = explicit_version or current_tag.removeprefix("v")
 
+    try:
+        update_options = infer_update_options(
+            text,
+            repository,
+            path.stem,
+            current_tag,
+            version_text,
+        )
+    except SystemExit as error:
+        raise ValueError(str(error)) from error
+
     return FormulaInfo(
         name=path.stem,
         path=path,
         repository=repository,
         current_tag=current_tag,
         current_version=parse_semver(version_text),
-        update_options=infer_update_options(
-            text,
-            repository,
-            path.stem,
-            current_tag,
-            version_text,
-        ),
+        update_options=update_options,
     )
 
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ and [gh shim migration to Octopool](https://gitcrawl.sh/gh-shim/).
 `Reconcile Formulae` is the self-healing fallback for formulae. Every three hours
 it derives each source repository from the formula's GitHub `homepage`, compares the formula with that repository's latest
 stable published release, and runs the same updater and checksum-download logic when the release is
-newer. It never downgrades, skips drafts and prereleases, and makes no commit when every formula is
+newer. Invalid formula metadata is reported and skipped so later formulae are still inspected.
+It never downgrades, skips drafts and prereleases, and makes no commit when every formula is
 current. Manual reconciles default to dry-run and can target one formula. The reconciler reads public
 release metadata and pushes with this tap's own `GITHUB_TOKEN`; it needs no cross-repository token or
 other external credential. The dispatch path remains the preferred low-latency path.

--- a/tests/test_reconcile_formulae.py
+++ b/tests/test_reconcile_formulae.py
@@ -292,6 +292,37 @@ class ReconcileFormulaeTest(unittest.TestCase):
         self.assertEqual(summary.skipped, 1)
         self.assertEqual(summary.current, 1)
 
+    def test_invalid_artifact_template_does_not_block_later_formulae(self) -> None:
+        bad = '''class Example < Formula
+  desc "Example"
+  homepage "https://github.com/openclaw/example"
+  version "1.2.3"
+  license "MIT"
+
+  url "https://github.com/openclaw/example/releases/download/v1.2.3/example_v1.2.3_{oops}.tar.gz"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+end
+'''
+        directory, root = self.make_tap(bad)
+        self.addCleanup(directory.cleanup)
+        bad_path = root / "Formula" / "example.rb"
+        (root / "Formula" / "working.rb").write_text(
+            formula_text().replace("Example", "Working").replace(
+                "openclaw/example", "openclaw/working"
+            ).replace("example", "working")
+        )
+        with self.assertRaises(ValueError):
+            reconcile_formulae.parse_formula(bad_path)
+        summary = reconcile_formulae.reconcile(
+            root,
+            None,
+            False,
+            release_lookup=lambda _: reconcile_formulae.Release("v1.2.3", False, False),
+        )
+        self.assertEqual(summary.scanned, 2)
+        self.assertEqual(summary.skipped, 1)
+        self.assertEqual(summary.current, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A malformed artifact template raised SystemExit outside the reconciler's per-formula error handler, aborting the remaining scan. Convert that exception to ValueError at the parser boundary so invalid formulae are skipped and later formulae are still inspected. The updater CLI keeps its existing validation behavior.

The earlier live CLI proof skipped malformed input and completed an authenticated lookup reporting Gitcrawl current. After independently rebasing onto main following #27, all 59 Python tests, Ruby syntax, Homebrew style, and CLI help smokes pass. This PR contains code, tests, and documentation only; the credited changelog entry is centralized in #34.
