### PR TITLE
fix: time out verified-hash git fetch and ls-remote

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -26,6 +26,7 @@ import urllib.request
 
 USER_AGENT = "steipete-homebrew-tap-updater"
 DOWNLOAD_TIMEOUT_SECONDS = 30
+GIT_NETWORK_TIMEOUT_SECONDS = 60
 TAP_TOKEN_PATTERN = re.compile(r"[a-z0-9][a-z0-9+@._-]*")
 REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9][A-Za-z0-9_.-]*")
 RELEASE_TAG_PATTERN = re.compile(r"v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?")
@@ -270,15 +271,19 @@ def verify_remote_source_tag(
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
     }
 
-    def git(command: list[str], failure: str) -> str:
-        completed = subprocess.run(
-            command,
-            cwd="/",
-            env=environment,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
+    def git(command: list[str], failure: str, *, timeout: float | None = None) -> str:
+        try:
+            completed = subprocess.run(
+                command,
+                cwd="/",
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise SystemExit(f"{failure}: timed out after {GIT_NETWORK_TIMEOUT_SECONDS}s") from error
         if completed.returncode != 0:
             detail = completed.stderr.strip() or failure
             raise SystemExit(f"{failure}: {detail}")
@@ -299,6 +304,7 @@ def verify_remote_source_tag(
                 f"{ref}:{ref}",
             ],
             "failed to fetch live source tag",
+            timeout=GIT_NETWORK_TIMEOUT_SECONDS,
         )
         fetched_tag_object = git(
             ["git", "-C", directory, "rev-parse", "--verify", f"{ref}^{{tag}}"],
@@ -315,6 +321,7 @@ def verify_remote_source_tag(
     output = git(
         ["git", "ls-remote", "--tags", source_url, ref, f"{ref}^{{}}"],
         "failed to read live source tag",
+        timeout=GIT_NETWORK_TIMEOUT_SECONDS,
     )
     validate_source_tag_refs(output, tag, source_tag_object, source_tag_commit)
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ source ref is the supplied annotated tag object and peeled commit, renders the t
 pairs directly from the supplied hashes, and never downloads release assets to recompute them.
 Partial or mixed legacy/verified input sets fail closed. The source repository remains responsible
 for verifying the public release bytes immediately before dispatch and again after the tap update,
-including its clean downstream Homebrew install proof.
+including its clean downstream Homebrew install proof. Each source-tag `git fetch` and
+`git ls-remote` verification has a 60-second deadline and aborts the update on timeout.
 
 Each successful verified dispatch must create one direct-child provenance commit; an already-current
 formula fails closed instead of reporting a trailerless no-op. The workflow revalidates the exact

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -699,11 +699,16 @@ end
         self.assertTrue(any(command[-1] == f"refs/tags/{tag}^{{commit}}" for command in commands))
         for call in run.call_args_list:
             options = call.kwargs
+            command = call.args[0]
             self.assertEqual(options["cwd"], "/")
             self.assertEqual(options["env"]["GIT_CONFIG_GLOBAL"], "/dev/null")
             self.assertEqual(options["env"]["GIT_TERMINAL_PROMPT"], "0")
             self.assertNotIn("GH_TOKEN", options["env"])
             self.assertNotIn("GITHUB_TOKEN", options["env"])
+            if "fetch" in command or "ls-remote" in command:
+                self.assertEqual(options["timeout"], update_formula.GIT_NETWORK_TIMEOUT_SECONDS)
+            else:
+                self.assertIsNone(options["timeout"])
 
     def test_remote_source_tag_rejects_a_non_commit_target(self) -> None:
         tag = "v1.2.3"
@@ -725,6 +730,42 @@ end
                     tag_object,
                     tag_commit,
                 )
+
+    def test_remote_source_tag_network_git_budget_is_documented(self) -> None:
+        self.assertEqual(update_formula.GIT_NETWORK_TIMEOUT_SECONDS, 60)
+
+    def test_remote_source_tag_network_git_timeout_fails_closed(self) -> None:
+        tag = "v1.2.3"
+        tag_object = "b" * 40
+        tag_commit = "a" * 40
+        output = f"{tag_object}\trefs/tags/{tag}\n{tag_commit}\trefs/tags/{tag}^{{}}\n"
+
+        for network_verb in ("fetch", "ls-remote"):
+            with self.subTest(command=network_verb):
+                def git_result(
+                    command: list[str],
+                    verb: str = network_verb,
+                    **kwargs: object,
+                ) -> update_formula.subprocess.CompletedProcess[str]:
+                    if verb in command:
+                        raise update_formula.subprocess.TimeoutExpired(command, timeout=kwargs.get("timeout"))
+                    stdout = ""
+                    if command[-1] == f"refs/tags/{tag}^{{tag}}":
+                        stdout = tag_object + "\n"
+                    elif command[-1] == f"refs/tags/{tag}^{{commit}}":
+                        stdout = tag_commit + "\n"
+                    elif "ls-remote" in command:
+                        stdout = output
+                    return update_formula.subprocess.CompletedProcess(command, 0, stdout, "")
+
+                with mock.patch.object(update_formula.subprocess, "run", side_effect=git_result):
+                    with self.assertRaisesRegex(SystemExit, r"timed out after 60s"):
+                        update_formula.verify_remote_source_tag(
+                            "openclaw/example",
+                            tag,
+                            tag_object,
+                            tag_commit,
+                        )
 
     def test_verified_hash_mode_renders_canonical_targets_without_downloading_assets(self) -> None:
         formula = '''class Example < Formula


### PR DESCRIPTION
Verified-hash updates could wait indefinitely on a stalled source-tag Git transport. The updater now gives `git fetch` and `git ls-remote` a 60-second subprocess deadline and aborts verification with a clear timeout error. Local Git initialization and object checks retain their existing behavior, as do exact annotated-tag validation and the credential-free Git environment.

Real macOS proof used the production verification helper and real Git processes. Public Gitcrawl v0.9.4 annotated-tag verification completed in 1.59 seconds. A process-local URL rewrite routed each selected network operation to a local HTTP server that accepted a Git request and withheld its response: fetch failed at 60.86 seconds, and the ls-remote scenario failed at 62.19 seconds including its successful setup fetch. Both reported the expected 60-second timeout. The harness cleaned up its temporary files, server, and process groups.

All 60 Python tests passed after rebasing. Independent local and committed-branch autoreview found no actionable P0–P2 findings. Documentation remains here; the credited changelog entry for @SebTardif is centralized in #34.
