### PR TITLE
fix: reject partial legacy formula updates

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -1350,9 +1350,11 @@ def main(argv: list[str] | None = None) -> int:
             replacements.append((match.start(), match.end(), replacement))
             seen_targets.add(target)
             print(f"{target}: {digest}  {url}")
-        for target in sorted(set(RELEASE_TARGETS).intersection(seen_targets ^ set(RELEASE_TARGETS))):
-            if target_url_count >= 4:
-                raise SystemExit(f"failed to update {target} in {path}")
+        if seen_targets != set(RELEASE_TARGETS):
+            missing = set(RELEASE_TARGETS) - seen_targets
+            unexpected = seen_targets - set(RELEASE_TARGETS)
+            target = sorted(missing or unexpected)[0]
+            raise SystemExit(f"failed to update {target} in {path}")
         for start, end, replacement in reversed(replacements):
             text = text[:start] + replacement + text[end:]
 

--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -413,6 +413,18 @@ def iter_url_sha_pairs(text: str) -> list[re.Match[str]]:
     )
 
 
+def iter_primary_url_sha_pairs(text: str) -> list[re.Match[str]]:
+    resources = list(re.finditer(
+        r'^(?P<indent>[ \t]+)resource [^\n]+\n.*?^(?P=indent)end(?:[ \t]*\n|$)',
+        text,
+        re.MULTILINE | re.DOTALL,
+    ))
+    return [
+        pair for pair in iter_url_sha_pairs(text)
+        if not any(resource.start() <= pair.start() < resource.end() for resource in resources)
+    ]
+
+
 def stanza_body(text: str, stanza: str) -> str | None:
     match = re.search(
         rf'^\s*{stanza}\s+do\s*$\n(?P<body>.*?)(?=^\s*(?:on_macos\s+do|on_linux\s+do|resource\s+|head |def |test do))',
@@ -1288,7 +1300,7 @@ def main(argv: list[str] | None = None) -> int:
     text = update_version(text, version)
     has_macos = has_stanza(text, "on_macos")
     has_linux = has_stanza(text, "on_linux")
-    url_sha_pairs = iter_url_sha_pairs(text)
+    url_sha_pairs = iter_primary_url_sha_pairs(text)
     classified_pairs = [(match, classify_target(match.group("url"), target_aliases, version)) for match in url_sha_pairs]
     target_url_count = sum(1 for _, target in classified_pairs if target)
     has_target_urls = target_url_count > 1 and not uses_stanza_url_mode(text, version)
@@ -1302,7 +1314,7 @@ def main(argv: list[str] | None = None) -> int:
             args.artifact_template,
             target_aliases,
         )
-        url_sha_pairs = iter_url_sha_pairs(text)
+        url_sha_pairs = iter_primary_url_sha_pairs(text)
         classified_pairs = [(match, classify_target(match.group("url"), target_aliases, version)) for match in url_sha_pairs]
         target_url_count = sum(1 for _, target in classified_pairs if target)
         has_target_urls = target_url_count > 1
@@ -1316,7 +1328,7 @@ def main(argv: list[str] | None = None) -> int:
             args.artifact_template,
             target_aliases,
         )
-        url_sha_pairs = iter_url_sha_pairs(text)
+        url_sha_pairs = iter_primary_url_sha_pairs(text)
         classified_pairs = [(match, classify_target(match.group("url"), target_aliases, version)) for match in url_sha_pairs]
         target_url_count = sum(1 for _, target in classified_pairs if target)
         has_target_urls = target_url_count > 1
@@ -1324,9 +1336,25 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("formulae with only one platform stanza need manual updates")
 
     if has_target_urls:
+        archives = [
+            match for match, _ in classified_pairs
+            if re.fullmatch(r'https://github\.com/[^"\n]+/archive/refs/tags/[^"\n]+', match.group("url"))
+        ]
+        if args.linux_url and len(archives) > 1:
+            raise SystemExit("expected at most one source archive URL/checksum pair")
+        for match, target in classified_pairs:
+            if target or (args.linux_url and match in archives):
+                continue
+            raise SystemExit(
+                f"unclassified release asset in {path}: {match.group('url')}; "
+                "supply --target-aliases for custom target names"
+            )
+        if target_url_count >= len(RELEASE_TARGETS):
+            missing = set(RELEASE_TARGETS) - {target for _, target in classified_pairs}
+            if missing:
+                raise SystemExit(f"failed to update {sorted(missing)[0]} in {path}")
         template = args.artifact_template or "{formula}_{version}_{target}.tar.gz"
         replacements: list[tuple[int, int, str]] = []
-        seen_targets: set[str] = set()
         for match, target in classified_pairs:
             if not target:
                 continue
@@ -1348,13 +1376,7 @@ def main(argv: list[str] | None = None) -> int:
                 f'{match.group("middle")}{digest}{match.group("suffix")}'
             )
             replacements.append((match.start(), match.end(), replacement))
-            seen_targets.add(target)
             print(f"{target}: {digest}  {url}")
-        if seen_targets != set(RELEASE_TARGETS):
-            missing = set(RELEASE_TARGETS) - seen_targets
-            unexpected = seen_targets - set(RELEASE_TARGETS)
-            target = sorted(missing or unexpected)[0]
-            raise SystemExit(f"failed to update {target} in {path}")
         for start, end, replacement in reversed(replacements):
             text = text[:start] + replacement + text[end:]
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Ruby syntax.
 
 Fleet release workflows use the optional `assets` JSON contract: exactly one `name` and `sha256`
 for each Darwin/Linux amd64/arm64 target. The updater renders those names and hashes verbatim,
-downloads all four public release assets, and refuses to commit on any digest mismatch. Omitting
+downloads all four public release assets, and refuses to commit on any digest mismatch. Legacy
+multi-target updates preserve smaller target inventories and resources, but reject unrecognized
+primary release assets before downloading or writing. Custom target names need `target_aliases`. Omitting
 `assets` preserves the legacy template and filename-guessing behavior for older callers.
 
 Other four-target binary releases can use the workflow's `verified-hashes-v1` contract. Supply all four

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -1032,10 +1032,11 @@ end
             os.chdir(root)
             try:
                 with (
-                    mock.patch.object(update_formula, "sha256", return_value="e" * 64),
-                    self.assertRaisesRegex(SystemExit, "failed to update linux_arm64"),
+                    mock.patch.object(update_formula, "sha256", return_value="e" * 64) as hashed,
+                    self.assertRaisesRegex(SystemExit, "unclassified release asset"),
                 ):
                     update_formula.main(arguments)
+                hashed.assert_not_called()
             finally:
                 os.chdir(previous_directory)
             after = path.read_bytes()
@@ -1044,6 +1045,95 @@ end
         self.assertNotIn(b'version "0.44.0"', after)
         self.assertIn(b"example_0.43.0_mystery.tar.gz", after)
         self.assertNotIn(("e" * 64).encode(), after)
+
+    def test_legacy_target_subsets_and_resources_remain_supported(self) -> None:
+        def formula_for(targets: tuple[str, ...]) -> str:
+            lines = [
+                "class Example < Formula",
+                '  desc "Example"',
+                '  homepage "https://github.com/openclaw/example"',
+                '  version "1.2.3"',
+                '  license "MIT"',
+            ]
+            for platform, prefix in (("macos", "darwin"), ("linux", "linux")):
+                selected = [target for target in targets if target.startswith(prefix)]
+                if not selected:
+                    continue
+                lines.append(f"  on_{platform} do")
+                for target in selected:
+                    cpu = "arm" if target.endswith("arm64") else "intel"
+                    lines.extend([
+                        f"    if Hardware::CPU.{cpu}?",
+                        f'      url "https://github.com/openclaw/example/releases/download/v1.2.3/example_1.2.3_{target}.tar.gz"',
+                        f'      sha256 "{"a" * 64}"',
+                        "    end",
+                    ])
+                lines.append("  end")
+            return "\n".join([*lines, "  def install", '    bin.install "example"', "  end", "end", ""])
+
+        inventories = (
+            ("darwin_arm64", "darwin_amd64"),
+            ("darwin_arm64", "darwin_amd64", "linux_amd64"),
+            ("darwin_universal", "linux_arm64", "linux_amd64"),
+            update_formula.RELEASE_TARGETS,
+        )
+        resource = (
+            '  resource "data" do\n'
+            '    url "https://example.org/data.tar.gz"\n'
+            f'    sha256 "{"f" * 64}"\n'
+            '  end\n'
+        )
+        for targets in inventories:
+            with self.subTest(targets=targets), tempfile.TemporaryDirectory() as directory:
+                root = pathlib.Path(directory)
+                (root / "Formula").mkdir()
+                path = root / "Formula/example.rb"
+                nested_resource = "\n".join("  " + line if line else line for line in resource.split("\n"))
+                fixture = formula_for(targets).replace("  def install", resource + "  def install")
+                fixture = fixture.replace("\n  end", "\n" + nested_resource + "  end", 1)
+                path.write_text(fixture)
+                previous = pathlib.Path.cwd()
+                os.chdir(root)
+                try:
+                    with mock.patch.object(update_formula, "sha256", return_value="e" * 64) as hashed:
+                        self.assertEqual(update_formula.main([
+                            "--formula", "example", "--repository", "openclaw/example", "--tag", "v1.2.4",
+                        ]), 0)
+                    self.assertEqual(hashed.call_count, len(targets))
+                finally:
+                    os.chdir(previous)
+                updated = path.read_text()
+                self.assertIn(resource, updated)
+                self.assertIn(nested_resource, updated)
+                self.assertEqual(updated.count('sha256 "' + "e" * 64), len(targets))
+                self.assertNotIn("example_1.2.3_", updated)
+
+    def test_legacy_explicit_source_archive_is_handled_but_unknown_pair_is_not(self) -> None:
+        archive = "https://github.com/openclaw/example/archive/refs/tags/v0.44.0.tar.gz"
+        pair = f'  url "{archive}"\n  sha256 "{"f" * 64}"\n'
+        for count in (1, 2):
+            with self.subTest(archives=count), tempfile.TemporaryDirectory() as directory:
+                root = pathlib.Path(directory)
+                (root / "Formula").mkdir()
+                path = root / "Formula/example.rb"
+                original = platform_install_formula().replace("  on_macos do", pair * count + "  on_macos do")
+                path.write_text(original)
+                previous = pathlib.Path.cwd()
+                os.chdir(root)
+                try:
+                    with mock.patch.object(update_formula, "sha256", return_value="e" * 64) as hashed:
+                        arguments = ["--formula", "example", "--repository", "openclaw/example",
+                                     "--tag", "v0.44.0", "--linux-url", archive]
+                        if count == 1:
+                            self.assertEqual(update_formula.main(arguments), 0)
+                            self.assertEqual(hashed.call_count, 5)
+                        else:
+                            with self.assertRaisesRegex(SystemExit, "at most one source archive"):
+                                update_formula.main(arguments)
+                            hashed.assert_not_called()
+                            self.assertEqual(path.read_text(), original)
+                finally:
+                    os.chdir(previous)
 
     def test_rejects_different_architecture_urls_in_one_stanza(self) -> None:
         text = '''class Example < Formula

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -999,6 +999,52 @@ end
         self.assertEqual(updated.count('sha256 "' + "e" * 64 + '"'), 4)
         self.assertNotIn('""', updated)
 
+    def test_multi_target_update_rejects_unclassified_pair_without_writing(self) -> None:
+        mystery_url = (
+            "https://github.com/openclaw/example/releases/download/v0.43.0/"
+            "example_0.43.0_mystery.tar.gz"
+        )
+        self.assertIsNone(update_formula.classify_target(mystery_url, {}, "0.43.0"))
+        formula = platform_install_formula().replace(
+            '  license "MIT"',
+            '  version "0.43.0"\n  license "MIT"',
+        ).replace("example_0.43.0_linux_arm64.tar.gz", "example_0.43.0_mystery.tar.gz")
+        classified = [
+            update_formula.classify_target(match.group("url"), {}, "0.43.0")
+            for match in update_formula.iter_url_sha_pairs(formula)
+        ]
+        self.assertEqual(classified.count(None), 1)
+        self.assertEqual(len([target for target in classified if target]), 3)
+        arguments = [
+            "--formula", "example",
+            "--tag", "v0.44.0",
+            "--repository", "openclaw/example",
+            "--artifact-template", "{formula}_{version}_{target}.tar.gz",
+        ]
+
+        previous_directory = pathlib.Path.cwd()
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "Formula").mkdir()
+            path = root / "Formula" / "example.rb"
+            path.write_text(formula)
+            before = path.read_bytes()
+            os.chdir(root)
+            try:
+                with (
+                    mock.patch.object(update_formula, "sha256", return_value="e" * 64),
+                    self.assertRaisesRegex(SystemExit, "failed to update linux_arm64"),
+                ):
+                    update_formula.main(arguments)
+            finally:
+                os.chdir(previous_directory)
+            after = path.read_bytes()
+
+        self.assertEqual(after, before)
+        self.assertNotIn(b'version "0.44.0"', after)
+        self.assertIn(b"example_0.43.0_mystery.tar.gz", after)
+        self.assertNotIn(("e" * 64).encode(), after)
+
     def test_rejects_different_architecture_urls_in_one_stanza(self) -> None:
         text = '''class Example < Formula
   version "1.0.0"


### PR DESCRIPTION
Legacy multi-target updates could silently skip an unrecognized primary asset, then save a formula containing a mix of old and new releases. The updater now checks the primary URL/checksum inventory before downloading or writing and rejects unclassified assets with guidance to use target aliases.

The guard preserves complete two- and three-target inventories, Darwin universal layouts, top-level and nested resources, and an explicitly handled Linux source archive. The existing completeness check for larger canonical inventories remains. Strict four-target requirements continue to belong to the explicit-assets and verified-hash contracts.

Validation: all 61 Python tests passed after rebasing, covering the no-download/no-write rejection, smaller and universal inventories, top-level and nested resources, and single/duplicate explicit source archives. A real updater CLI run against a scratch copy of the Gitcrawl formula rejected an unrecognized asset and left the file byte-identical. A macOS-only inventory then updated successfully by downloading both public Gitcrawl v0.9.4 archives and matching their published formula checksums.

Maintainer follow-up narrows the original guard to preserve supported legacy inputs and adds documentation; the credited changelog entry for @SebTardif is centralized in #34. The independent Linux archive URL/checksum repair remains in #32.
