### PR TITLE
fix: validate checksum redirects before following them

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -184,12 +184,24 @@ def ruby_string(value: str) -> str:
     return f'"{escaped}"'
 
 
+class DownloadRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # urllib resolves relative Locations before this hook, but has not followed them yet.
+        try:
+            validate_url(newurl, "redirected download URL")
+        except SystemExit:
+            fp.close()
+            raise
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
 def sha256(url: str) -> str:
     validate_url(url, "download URL")
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     digest = hashlib.sha256()
+    opener = urllib.request.build_opener(DownloadRedirectHandler())
     try:
-        with urllib.request.urlopen(request, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
+        with opener.open(request, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
             while chunk := response.read(1024 * 1024):
                 digest.update(chunk)
     except TimeoutError as error:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add OCM v0.2.39 for macOS ARM64/Intel and Linux x86_64, preserving signed release binaries, reconciling Rust-target archives, and testing installed packages on all three platforms. Use `brew upgrade openclaw/tap/ocm`; this initial binary does not guard against self-update.
 - Add the Peekaboo 4.3.1 universal macOS formula and list it in the package guide.
 - Remove the deprecated Goplaces postflight hook, preserving quarantine on signed, notarized binaries and eliminating Homebrew's warning; thanks @karbo-hub.
+- Validate every checksum-download redirect before following it, rejecting HTTPS downgrades, credentials, and fragments while preserving the existing host contract; thanks @SebTardif.
 - Automatically reconcile formulae with their latest stable source releases every three hours without downgrading or selecting drafts and prereleases.
 - Reject unrecognized release assets before partial updates while preserving smaller legacy target inventories and resources; thanks @SebTardif.
 - Keep Linux source-archive URLs and checksums in sync during multi-target updates; thanks @SebTardif.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ GitHub repository in `owner/repo` form. Optional artifact inputs must resolve to
 assets and may use only the placeholders documented by the workflow. Downloads use a 30-second
 socket inactivity timeout and stream archive bytes without imposing a size limit. This timeout
 bounds stalled socket operations, not the total duration of a progressing download.
+Every redirect destination is validated before it is requested: HTTPS is required, and
+credentials and fragments are rejected. Relative HTTPS redirects remain supported. This
+does not impose a public-only host policy: private, localhost, and numeric host spellings
+such as `127.1`, `2130706433`, and `0x7f000001` remain allowed, subject to normal TLS
+certificate verification. DNS/IP restrictions are outside this download contract.
 
 **Crabbox uses the ordinary four-target `assets` handoff after publication.** The
 [Crabbox release process](https://github.com/openclaw/crabbox/blob/main/docs/RELEASING.md)

--- a/tests/test_download_redirects.py
+++ b/tests/test_download_redirects.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import hashlib
+import http.server
+import importlib.util
+import os
+import pathlib
+import ssl
+import subprocess
+import tempfile
+import threading
+import unittest
+import urllib.error
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / ".github/scripts/update_formula.py"
+SPEC = importlib.util.spec_from_file_location("redirect_updater", SCRIPT)
+assert SPEC and SPEC.loader
+update_formula = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(update_formula)
+
+
+class DownloadRedirectTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(temporary.cleanup)
+        root = pathlib.Path(temporary.name)
+        cls.certificate = root / "certificate.pem"
+        key = root / "key.pem"
+        config = root / "openssl.cnf"
+        config.write_text(
+            "[req]\nprompt = no\ndistinguished_name = dn\nx509_extensions = extensions\n"
+            "[dn]\nCN = localhost\n[extensions]\n"
+            "subjectAltName = DNS:localhost,IP:127.0.0.1\n"
+            "basicConstraints = critical,CA:TRUE\n"
+        )
+        subprocess.run(
+            ["openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes", "-sha256",
+             "-days", "1", "-config", str(config), "-keyout", str(key),
+             "-out", str(cls.certificate)],
+            check=True, capture_output=True, timeout=30,
+        )
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(cls.certificate, key)
+        cls.payload = b"release archive through verified TLS\n"
+        cls.requests: list[tuple[str, str]] = []
+        cls.routes: dict[str, tuple[int, str]] = {}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                cls.requests.append((self.server.scheme, self.path))
+                if self.path == "/asset":
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(cls.payload)
+                else:
+                    code, location = cls.routes[self.path]
+                    self.send_response(code)
+                    self.send_header("Location", location)
+                    self.end_headers()
+
+            def log_message(self, format: str, *args: object) -> None:
+                pass
+
+        for scheme in ("http", "https"):
+            server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+            cls.addClassCleanup(server.server_close)
+            server.scheme = scheme
+            if scheme == "https":
+                server.socket = context.wrap_socket(server.socket, server_side=True)
+            thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True)
+            thread.start()
+            cls.addClassCleanup(thread.join, 5)
+            cls.addClassCleanup(server.shutdown)
+            setattr(cls, scheme, f"{scheme}://127.0.0.1:{server.server_port}")
+
+    def setUp(self) -> None:
+        self.requests.clear()
+        self.routes.clear()
+        # Trust only the fixture certificate for this run; TLS verification stays enabled.
+        environment = mock.patch.dict(os.environ, {"SSL_CERT_FILE": str(self.certificate), "no_proxy": "*"})
+        environment.start()
+        self.addCleanup(environment.stop)
+
+    def test_allowed_relative_and_cross_host_https_redirects_hash_body(self) -> None:
+        for code in (301, 302, 303, 307, 308):
+            with self.subTest(code=code):
+                self.requests.clear()
+                self.routes.update({
+                    "/start": (code, "/next"),
+                    "/next": (code, self.https.replace("127.0.0.1", "localhost") + "/asset"),
+                })
+                self.assertEqual(update_formula.sha256(self.https + "/start"), hashlib.sha256(self.payload).hexdigest())
+                self.assertEqual(self.requests, [("https", "/start"), ("https", "/next"), ("https", "/asset")])
+
+    def test_https_http_https_chain_never_requests_http_hop(self) -> None:
+        for code in (301, 302, 303, 307, 308):
+            with self.subTest(code=code):
+                self.requests.clear()
+                self.routes.update({
+                    "/start": (code, self.http + "/back-to-https"),
+                    "/back-to-https": (302, self.https + "/asset"),
+                })
+                with self.assertRaisesRegex(SystemExit, "invalid redirected download URL"):
+                    update_formula.sha256(self.https + "/start")
+                self.assertEqual(self.requests, [("https", "/start")])
+
+    def test_forbidden_location_after_allowed_hop_is_never_requested(self) -> None:
+        for location in (
+            self.http + "/asset",
+            "ftp://127.0.0.1/asset",
+            self.https.replace("https://", "https://user:password@") + "/asset",
+            self.https + "/asset#fragment",
+            "/asset#fragment",
+        ):
+            with self.subTest(location=location):
+                self.requests.clear()
+                self.routes.update({"/start": (302, "/next"), "/next": (302, location)})
+                with self.assertRaisesRegex(SystemExit, "invalid redirected download URL"):
+                    update_formula.sha256(self.https + "/start")
+                self.assertEqual(self.requests, [("https", "/start"), ("https", "/next")])
+
+    def test_redirects_keep_certificate_verification_enabled(self) -> None:
+        # 127.1 reaches the same server but is not covered by its certificate.
+        self.routes["/start"] = (302, self.https.replace("127.0.0.1", "127.1") + "/asset")
+        with self.assertRaises(urllib.error.URLError) as error:
+            update_formula.sha256(self.https + "/start")
+        self.assertIsInstance(error.exception.reason, ssl.SSLCertVerificationError)
+        self.assertEqual(self.requests, [("https", "/start")])
+
+    def test_private_and_numeric_hosts_keep_existing_url_contract(self) -> None:
+        # Public-only sources and DNS/IP restrictions are a separate policy decision.
+        for host in ("localhost", "127.0.0.1", "[::1]", "192.168.1.1", "2130706433", "127.1", "0x7f000001"):
+            with self.subTest(host=host):
+                url = f"https://{host}/asset"
+                self.assertEqual(update_formula.validate_url(url, "download URL"), url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reconcile_formulae.py
+++ b/tests/test_reconcile_formulae.py
@@ -114,7 +114,7 @@ class ReconcileFormulaeTest(unittest.TestCase):
                     ocm.write_text(original)
                     downloads = []
 
-                    def response(request, **kwargs):
+                    def response(request, data=None, timeout=None):
                         url = request.full_url
                         if url == "https://api.github.com/repos/openclaw/ocm/releases/latest":
                             return io.BytesIO(json.dumps({"tag_name": newer}).encode())
@@ -138,7 +138,7 @@ class ReconcileFormulaeTest(unittest.TestCase):
 
                     output = io.StringIO()
                     with (
-                        mock.patch.object(reconcile_formulae.urllib.request, "urlopen", side_effect=response),
+                        mock.patch.object(reconcile_formulae.urllib.request.OpenerDirector, "open", side_effect=response),
                         mock.patch.object(reconcile_formulae.subprocess, "run", side_effect=run),
                         contextlib.redirect_stdout(output),
                     ):
@@ -180,7 +180,7 @@ class ReconcileFormulaeTest(unittest.TestCase):
                         crabbox.write_text(original)
                         downloads = []
 
-                        def response(request, **kwargs):
+                        def response(request, data=None, timeout=None):
                             url = request.full_url
                             if url == "https://api.github.com/repos/openclaw/crabbox/releases/latest":
                                 if tag is None:
@@ -211,7 +211,7 @@ class ReconcileFormulaeTest(unittest.TestCase):
 
                         output = io.StringIO()
                         with (
-                            mock.patch.object(reconcile_formulae.urllib.request, "urlopen", side_effect=response),
+                            mock.patch.object(reconcile_formulae.urllib.request.OpenerDirector, "open", side_effect=response),
                             mock.patch.object(reconcile_formulae.subprocess, "run", side_effect=run) as update,
                             contextlib.redirect_stdout(output),
                         ):

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -89,7 +89,7 @@ class UpdateFormulaTest(unittest.TestCase):
                     seed_formula=mock.DEFAULT,
                     update_cask=mock.DEFAULT,
                 ) as operations,
-                mock.patch.object(update_formula.urllib.request, "urlopen") as network,
+                mock.patch.object(update_formula.urllib.request.OpenerDirector, "open") as network,
                 mock.patch.object(update_formula.subprocess, "run") as process,
                 mock.patch.object(pathlib.Path, "write_text") as write,
             ):
@@ -174,7 +174,7 @@ class UpdateFormulaTest(unittest.TestCase):
                             return io.BytesIO(urls[request.full_url])
 
                         with (
-                            mock.patch.object(update_formula.urllib.request, "urlopen", side_effect=download) as network,
+                            mock.patch.object(update_formula.urllib.request.OpenerDirector, "open", side_effect=download) as network,
                             mock.patch.object(update_formula, "verify_remote_source_tag") as verify_tag,
                         ):
                             self.assertEqual(update_formula.main(crabbox_arguments(mode)), 0)
@@ -221,7 +221,7 @@ class UpdateFormulaTest(unittest.TestCase):
                         os.chdir(root)
                         try:
                             with (
-                                mock.patch.object(update_formula.urllib.request, "urlopen", side_effect=download) as network,
+                                mock.patch.object(update_formula.urllib.request.OpenerDirector, "open", side_effect=download) as network,
                                 mock.patch.object(update_formula, "update_cask") as cask,
                                 self.assertRaisesRegex(
                                     (SystemExit, urllib.error.HTTPError),
@@ -249,7 +249,7 @@ class UpdateFormulaTest(unittest.TestCase):
             previous_directory = pathlib.Path.cwd()
             os.chdir(root)
             try:
-                with mock.patch.object(update_formula.urllib.request, "urlopen", side_effect=download) as network:
+                with mock.patch.object(update_formula.urllib.request.OpenerDirector, "open", side_effect=download) as network:
                     self.assertEqual(update_formula.main(crabbox_arguments("explicit-assets")), 0)
                 self.assertEqual(network.call_count, 4)
             finally:
@@ -1463,8 +1463,8 @@ end
         payload = b"formula-asset"
         url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
         with mock.patch.object(
-            update_formula.urllib.request,
-            "urlopen",
+            update_formula.urllib.request.OpenerDirector,
+            "open",
             return_value=io.BytesIO(payload),
         ) as network:
             digest = update_formula.sha256(url)
@@ -1477,8 +1477,8 @@ end
         url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
         with (
             mock.patch.object(
-                update_formula.urllib.request,
-                "urlopen",
+                update_formula.urllib.request.OpenerDirector,
+                "open",
                 side_effect=TimeoutError("timed out"),
             ),
             self.assertRaisesRegex(SystemExit, r"timed out downloading .* after 30s"),
@@ -1489,8 +1489,8 @@ end
         url = "https://github.com/openclaw/example/releases/download/v1.0.0/example.tar.gz"
         with (
             mock.patch.object(
-                update_formula.urllib.request,
-                "urlopen",
+                update_formula.urllib.request.OpenerDirector,
+                "open",
                 side_effect=urllib.error.URLError(TimeoutError("timed out")),
             ),
             self.assertRaisesRegex(SystemExit, r"timed out downloading .* after 30s"),

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -246,7 +246,7 @@ def download(request, **_kwargs):
         if os.environ["MODE"] == "wrong-hash":
             return io.BytesIO(b"wrong bytes")
     return io.BytesIO(target.encode())
-with mock.patch("urllib.request.urlopen", side_effect=download), \\
+with mock.patch("urllib.request.OpenerDirector.open", side_effect=download), \\
      mock.patch("subprocess.run", side_effect=AssertionError("source tag lookup attempted")):
     runpy.run_path(sys.argv[0], run_name="__main__")
 ''')


### PR DESCRIPTION
Checksum downloads previously validated only the initial URL. urllib could follow HTTPS → HTTP → HTTPS, issue the forbidden HTTP request, and hash the final response. This change validates every resolved redirect destination before following it, including relative Locations and redirects after an earlier allowed hop.

The maintainer repair deliberately preserves the current host contract: **any HTTPS host remains allowed**. This PR rejects non-HTTPS destinations, credentials, and fragments using the existing validator. It retains normal TLS verification, urllib's redirect limits, and the 30-second socket inactivity timeout. Public-only sources, private-IP restrictions, numeric-host classification, and DNS restrictions are outside this PR and remain a separate policy decision.

The contributor branch was rebased onto main `e0786e7c0c656dffb388c06e81f85362fec4bfe9`, retaining Sebastien Tardif as commit author. Reviewed head: `9f4c2afe15c4b9d87acb175546457b0a2cfcb51d`.

Validation:

- `python3 -m unittest discover -s tests -v`: all 73 tests pass.
- `python3 -m unittest discover -s tests -p test_download_redirects.py -v`: real local HTTPS/HTTP servers cover 301, 302, 303, 307, and 308; valid relative and cross-host HTTPS redirects; credentials/fragments after an allowed hop; rejection of an invalid TLS hostname; and retained private/numeric host acceptance. A generated certificate is trusted only for the fixture; TLS verification is never disabled.
- Direct before/after transport proof: main requests `HTTPS /start`, `HTTP /back-to-https`, then `HTTPS /asset`; this head requests only `HTTPS /start` and rejects the downgrade. A valid HTTPS chain still hashes correctly.
- Live GitHub release → HTTPS CDN download of the pinned Goplaces ARM64 0.4.9 archive matches SHA-256 `8c133880df665101777cfb6e395f1336521870980c1866584076e9db2978250a`.
- Ruby syntax passes for all 19 package files; Homebrew formula style passes for all 18 formulae. Pre-commit and committed-branch isolated Codex autoreviews are both clean through P2.

The README documents the preserved host contract, including `127.1`, `2130706433`, and `0x7f000001`. One Unreleased bullet credits @SebTardif. No new dependency or workflow change is introduced.

Exact-head CI is green: [CI](https://github.com/openclaw/homebrew-tap/actions/runs/34101090898) and [OCM Install](https://github.com/openclaw/homebrew-tap/actions/runs/34101090878), including macOS ARM64, macOS Intel, and Linux x86_64.
