### PR TITLE
fix: update linux archive URL in multi-target mode

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -1392,9 +1392,9 @@ def main(argv: list[str] | None = None) -> int:
             linux_sha = sha256(linux_url)
             text = replace_zero_or_one(
                 text,
-                r'(?P<prefix>url "https://github\.com/[^"]+/archive/refs/tags/[^"]+"\n\s+sha256 ")[0-9a-f]+(?P<suffix>")',
-                rf'\g<prefix>{linux_sha}\g<suffix>',
-                "source archive sha256",
+                r'(?P<prefix>url ")https://github\.com/[^"]+/archive/refs/tags/[^"]+(?P<middle>"\n\s+sha256 ")[0-9a-f]+(?P<suffix>")',
+                rf'\g<prefix>{linux_url}\g<middle>{linux_sha}\g<suffix>',
+                "source archive url and sha256",
             )
             print(f"Linux source: {linux_sha}  {linux_url}")
     else:

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ caller-supplied hashes without public downloads cannot update that formula. Its 
 `--verify-source-tag-only` check still accepts the complete verified-hash input set without writing.
 
 Existing `Formula/*.rb` files own each tool's caveats and install instructions. The updater
-preserves that content while changing release metadata, so maintain it here rather than in an
-upstream release workflow. Newly generated formulae remain in memory until all required
-checksum downloads and rendering succeed, so failed creation leaves no placeholder file.
+preserves that content while changing release metadata. In legacy multi-target mode, a supplied
+`linux_url` refreshes both the matching GitHub source-archive URL and its checksum. Maintain
+formula-specific content here rather than in an upstream release workflow. Newly generated
+formulae remain in memory until all required checksum downloads and rendering succeed, so
+failed creation leaves no placeholder file.
 For Gitcrawl, see the [configuration reference](https://gitcrawl.sh/configuration/)
 and [gh shim migration to Octopool](https://gitcrawl.sh/gh-shim/).
 

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -1239,6 +1239,49 @@ end
                 finally:
                     os.chdir(previous)
 
+    def test_multi_target_linux_url_updates_archive_url_and_sha(self) -> None:
+        old_archive = "https://github.com/openclaw/example/archive/refs/tags/v0.43.0.tar.gz"
+        new_archive = "https://github.com/openclaw/example/archive/refs/tags/v0.44.0.tar.gz"
+        formula = platform_install_formula().replace(
+            '  license "MIT"\n',
+            (
+                '  version "0.43.0"\n'
+                '  license "MIT"\n'
+                f'  url "{old_archive}"\n'
+                f'  sha256 "{"f" * 64}"\n'
+            ),
+        )
+        arguments = [
+            "--formula", "example",
+            "--tag", "v0.44.0",
+            "--repository", "openclaw/example",
+            "--artifact-template", "{formula}_{version}_{target}.tar.gz",
+            "--linux-url", new_archive,
+        ]
+
+        def digest_for(url: str) -> str:
+            return ("c" if url == new_archive else "e") * 64
+
+        previous_directory = pathlib.Path.cwd()
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "Formula").mkdir()
+            path = root / "Formula" / "example.rb"
+            path.write_text(formula)
+            os.chdir(root)
+            try:
+                with mock.patch.object(update_formula, "sha256", side_effect=digest_for):
+                    self.assertEqual(update_formula.main(arguments), 0)
+            finally:
+                os.chdir(previous_directory)
+            updated = path.read_text()
+
+        self.assertIn(f'url "{new_archive}"', updated)
+        self.assertNotIn(old_archive, updated)
+        self.assertIn('sha256 "' + "c" * 64 + '"', updated)
+        self.assertNotIn("f" * 64, updated)
+        self.assertIn("example_0.44.0_linux_amd64.tar.gz", updated)
+
     def test_rejects_different_architecture_urls_in_one_stanza(self) -> None:
         text = '''class Example < Formula
   version "1.0.0"


### PR DESCRIPTION
A legacy multi-target update with `--linux-url` hashed the new source archive but retained the previous archive URL. This pairs the replacement URL with its downloaded checksum, preventing Homebrew from fetching old bytes against the new digest.

Rebased onto main after the inventory-validation and safe-creation fixes landed. Their test methods are preserved unchanged, and this PR adds the separate source-archive regression. The README documents both safe creation and synchronized archive updates. The credited release note is already on main through #34.

Validation on the rebased head: all 67 Python tests, all 15 formulae's Ruby syntax and Homebrew style checks, both CLI help smokes, and the real updater CLI archive proof passed. The CLI updated a scratch Gitcrawl formula from v0.9.3 references to v0.9.4 using all four public binary archives and the source archive. All binary digests matched the checked-in formula, and an independent curl download matched the source SHA-256: `a1c06095d6562f92b3aa807fcf43ccdc49aadbe39e7dc061d369958cbf6e789f`.
