### PR TITLE
fix: write new formulae only after checksums succeed

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -1277,13 +1277,14 @@ def main(argv: list[str] | None = None) -> int:
     validate_url(linux_url, "Linux URL")
 
     path = tap_path("Formula", args.formula)
-    if not path.exists():
+    created = False
+    if path.exists():
+        text = path.read_text()
+    else:
         template = args.artifact_template or "{formula}_{version}_{target}.tar.gz"
         description = args.description or f"{args.formula} command-line tool"
-        path.write_text(seed_formula(args.formula, args.repository, version, description, template))
-        print(f"created {path}")
-
-    text = path.read_text()
+        text = seed_formula(args.formula, args.repository, version, description, template)
+        created = True
     text = update_repository_metadata(text, args.repository)
     text = update_version(text, version)
     has_macos = has_stanza(text, "on_macos")
@@ -1379,7 +1380,8 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Linux: {linux_sha}  {linux_url}")
 
     path.write_text(text)
-
+    if created:
+        print(f"created {path}")
     print(f"updated {path} to {version}")
     if args.cask:
         assert cask_artifact is not None

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ caller-supplied hashes without public downloads cannot update that formula. Its 
 
 Existing `Formula/*.rb` files own each tool's caveats and install instructions. The updater
 preserves that content while changing release metadata, so maintain it here rather than in an
-upstream release workflow. For Gitcrawl, see the [configuration reference](https://gitcrawl.sh/configuration/)
+upstream release workflow. Newly generated formulae remain in memory until all required
+checksum downloads and rendering succeed, so failed creation leaves no placeholder file.
+For Gitcrawl, see the [configuration reference](https://gitcrawl.sh/configuration/)
 and [gh shim migration to Octopool](https://gitcrawl.sh/gh-shim/).
 
 `Reconcile Formulae` is the self-healing fallback for formulae. Every three hours

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -934,6 +934,69 @@ end
 
         self.assertIn(r'desc "A \"quoted\" \#{system(\"id\")} description"', seeded)
 
+    def test_seeded_formula_is_not_written_when_checksum_download_fails(self) -> None:
+        arguments = [
+            "--formula", "example",
+            "--tag", "v1.2.3",
+            "--repository", "openclaw/example",
+            "--artifact-template", "{formula}_{version}_{target}.tar.gz",
+        ]
+        for when in ("first-target", "later-target"):
+            with self.subTest(when=when), tempfile.TemporaryDirectory() as directory:
+                root = pathlib.Path(directory)
+                (root / "Formula").mkdir()
+                path = root / "Formula" / "example.rb"
+                seen = {"n": 0}
+
+                def download(url: str) -> str:
+                    self.assertFalse(path.exists())
+                    seen["n"] += 1
+                    if when == "first-target" or seen["n"] > 1:
+                        raise SystemExit("download failed")
+                    return "e" * 64
+
+                previous_directory = pathlib.Path.cwd()
+                os.chdir(root)
+                try:
+                    with mock.patch.object(update_formula, "sha256", side_effect=download):
+                        with self.assertRaisesRegex(SystemExit, "download failed"):
+                            update_formula.main(arguments)
+                finally:
+                    os.chdir(previous_directory)
+                self.assertFalse(path.exists())
+                self.assertEqual(list(root.rglob("*.rb")), [])
+
+    def test_seeded_formula_is_written_only_after_checksums_succeed(self) -> None:
+        arguments = [
+            "--formula", "example",
+            "--tag", "v1.2.3",
+            "--repository", "openclaw/example",
+            "--artifact-template", "{formula}_{version}_{target}.tar.gz",
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "Formula").mkdir()
+            path = root / "Formula" / "example.rb"
+
+            def download(url: str) -> str:
+                self.assertFalse(path.exists())
+                return hashlib.sha256(url.encode()).hexdigest()
+
+            previous_directory = pathlib.Path.cwd()
+            os.chdir(root)
+            try:
+                with mock.patch.object(update_formula, "sha256", side_effect=download) as hashed:
+                    self.assertEqual(update_formula.main(arguments), 0)
+                self.assertEqual(hashed.call_count, 4)
+            finally:
+                os.chdir(previous_directory)
+            updated = path.read_text()
+
+        self.assertNotIn("0" * 64, updated)
+        self.assertEqual(updated.count("sha256 "), 4)
+        for target in update_formula.RELEASE_TARGETS:
+            self.assertIn(f"example_#{{version}}_{target}.tar.gz", updated)
+
     def test_updates_duplicate_source_url_checksums_in_stanza(self) -> None:
         text = '''class Camsnap < Formula
   version "0.2.0"


### PR DESCRIPTION
Creating a missing formula through the legacy template path wrote four placeholder checksums to disk before downloading release assets. A failed download therefore left an invalid formula behind. This change keeps the seed in memory and reuses the existing final write after checksum calculation and rendering succeed.

Real macOS proof invoked the updater CLI against public Gitcrawl v0.9.4 release URLs in an empty scratch tap. A deliberately missing first asset returned HTTP 404 and left no formula. A later missing Linux asset returned HTTP 404 after both Darwin downloads, again leaving no formula. A final successful run downloaded all four real archives, created the formula, and matched every checksum against the checked-in Gitcrawl formula.

All 60 Python tests passed after rebasing. The maintainer follow-up adds documentation; the credited changelog entry thanking @SebTardif is centralized in #34. Optional cask handling remains the existing separate update path; this change addresses premature formula creation.
