### PR TITLE
chore: update slacrawl and consolidate tap release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,19 @@
 
 ## Unreleased
 
-- Update the `goplaces` cask to 0.4.9 with the `--radius` alias and signed, notarized macOS binaries.
+**Highlights:** Release updates fail cleanly without publishing partial or placeholder formulae, while preserving supported legacy layouts.
+
+- Reject unrecognized release assets before partial updates while preserving smaller legacy target inventories and resources; thanks @SebTardif.
+- Keep Linux source-archive URLs and checksums in sync during multi-target updates; thanks @SebTardif.
+- Leave no zero-checksum formula behind when a new formula download fails; thanks @SebTardif.
+- Keep reconciling later formulae when an artifact template is invalid; thanks @SebTardif.
 - Fail stalled formula and cask downloads with a 30-second socket timeout; thanks @SebTardif.
+- Stop stalled source-tag Git fetches and lookups after 60 seconds; thanks @SebTardif.
+- Update the `slacrawl` formula to 0.8.7 with verified macOS and Linux archives for Intel and ARM.
+- Update the `goplaces` cask to 0.4.9 with the `--radius` alias and signed, notarized macOS binaries.
+- Automatically reconcile formulae with their latest stable source releases every three hours without downgrading or selecting drafts and prereleases.
+- Preserve formula-owned install instructions and caveats while accepting exact four-platform release asset inventories and verified source-tag provenance.
+- Align Crabbox tap updates with published releases and downloaded checksums, with reconciliation as a recovery path.
+- Validate release-dispatch inputs and require protected-default-branch execution for formula automation.
+- Correct Gitcrawl configuration paths and direct GitHub shim users to Octopool.
+- Provide Homebrew formulae for axorc, clawscan, crabbox, crabfleet, crawlbar, discrawl, gitcrawl, gogcli, graincrawl, notcrawl, octopool, slacrawl, telecrawl, wacli, and wacrawl, plus the Goplaces cask.

--- a/Formula/slacrawl.rb
+++ b/Formula/slacrawl.rb
@@ -1,26 +1,26 @@
 class Slacrawl < Formula
   desc "Go-based CLI for mirroring Slack workspace data into local SQLite"
   homepage "https://github.com/openclaw/slacrawl"
-  version "0.8.6"
+  version "0.8.7"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.6/slacrawl_0.8.6_darwin_arm64.tar.gz"
-      sha256 "ea7259edb4e6bac8c38df379a4525d84ba3a4eab9d681c9efed4d5a103427de9"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.7/slacrawl_0.8.7_darwin_arm64.tar.gz"
+      sha256 "7dcaeacde58974d24255e3cb76ebcfa91ccdb3872571ae69eae82abfe3e14d66"
     else
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.6/slacrawl_0.8.6_darwin_amd64.tar.gz"
-      sha256 "71f446a9c58dab78bd4f528adb6db099c9c7fe1c06b3b944d9cdb18cb4644fa0"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.7/slacrawl_0.8.7_darwin_amd64.tar.gz"
+      sha256 "378c0b3c8c157adead024b0e7a178f277c226e8ff7aca8b260a9877a5adbb665"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.6/slacrawl_0.8.6_linux_arm64.tar.gz"
-      sha256 "c8f4fefc4954a6309e5ec41f8942fd1f1f65aa999677ffc1165729add4894ca9"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.7/slacrawl_0.8.7_linux_arm64.tar.gz"
+      sha256 "7ae75a47d1d1195e702185c74cc645438bef0a7242545e0fc82f04544dfb5d14"
     else
-      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.6/slacrawl_0.8.6_linux_amd64.tar.gz"
-      sha256 "b03c1cdd80644c77e207400e8f755aeb0cbc153a3903b6a0451ee19725824d91"
+      url "https://github.com/openclaw/slacrawl/releases/download/v0.8.7/slacrawl_0.8.7_linux_amd64.tar.gz"
+      sha256 "c8efe9a7298c914f89c45deae590e13dea954467d4d90e185dacd0961a5ab5a8"
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ brew install --cask openclaw/tap/<name>
 ### Formulae
 
 - `axorc` — Inspect and automate macOS Accessibility from the shell
+- `clawscan` — Agent-skill security scanner harness for ClawHub
 - `crabbox` — Remote Linux test boxes for dirty worktrees and CI hydration
 - `crabfleet` — Fleet management CLI for Crabbox workers
 - `crawlbar` — macOS menu bar control plane for local-first crawler CLIs


### PR DESCRIPTION
The tap still points to Slacrawl 0.8.6 although 0.8.7 is published. This updates all four platform URLs and checksums, lists the existing Clawscan formula in the README, and consolidates `Unreleased` for the prepared maintenance changes.

PR #27 is merged. Land this PR after #28, #29, #30, #32, and #33. The release notes include those repairs. #31 remains a separate maintainer decision about redirect and artifact-host policy.

Verification: the production updater downloaded all four public Slacrawl 0.8.7 archives. The macOS ARM archive was independently checked against its formula checksum, extracted in a temporary directory, and the native binary passed `--version` (0.8.7) and the formula's `--help` smoke. All 58 baseline Python tests passed after rebasing. All 15 formulae passed Ruby syntax and Homebrew style. Independent local and branch autoreview found no actionable P0–P2 findings.

This repository has no tags or standalone GitHub releases. These are maintenance changes distributed through the Homebrew tap after merge; no new version number, tag, GitHub Release, npm publication, or notarization is proposed. The source-project artifacts are already published. Temporary downloaded archives and extracted binaries were removed.

Independently rebased onto main at `1aac54a16df7568b3eb3e8b38b2b44f674a591c1`. This PR owns the single complete Unreleased section, including all six credited updater fixes; the other five pending code PRs contain no changelog changes.
