### PR TITLE
feat(peekaboo): seed universal macOS formula

### DIFF
--- a/Formula/peekaboo.rb
+++ b/Formula/peekaboo.rb
@@ -2,7 +2,6 @@ class Peekaboo < Formula
   desc "Lightning-fast macOS screenshots & AI vision analysis"
   homepage "https://github.com/openclaw/Peekaboo"
   url "https://github.com/openclaw/Peekaboo/releases/download/v4.3.0/peekaboo-macos-universal.tar.gz"
-  version "4.3.0"
   sha256 "fec965e4bd6371b8fb017fb582e8d31c6a59628f77e266878f45cf1d4844836f"
   license "MIT"
 

--- a/Formula/peekaboo.rb
+++ b/Formula/peekaboo.rb
@@ -1,0 +1,40 @@
+class Peekaboo < Formula
+  desc "Lightning-fast macOS screenshots & AI vision analysis"
+  homepage "https://github.com/openclaw/Peekaboo"
+  url "https://github.com/openclaw/Peekaboo/releases/download/v4.3.0/peekaboo-macos-universal.tar.gz"
+  version "4.3.0"
+  sha256 "fec965e4bd6371b8fb017fb582e8d31c6a59628f77e266878f45cf1d4844836f"
+  license "MIT"
+
+  # macOS Sequoia (15.0) or later required
+  depends_on macos: :sequoia
+
+  def install
+    bin.install "peekaboo", *Dir["libswiftCompatibility*.dylib"]
+  end
+
+  def caveats
+    <<~EOS
+      Peekaboo requires Screen Recording permission to capture screenshots.
+
+      To grant permission:
+      1. Open System Settings > Privacy & Security > Screen & System Audio Recording
+      2. Enable access for your Terminal application
+
+      For AI analysis features, configure your AI providers:
+        export PEEKABOO_AI_PROVIDERS="openai/gpt-5.1,anthropic/claude-sonnet-4.5"
+        export OPENAI_API_KEY="your-api-key"
+
+      Or create a config file:
+        peekaboo config init
+    EOS
+  end
+
+  test do
+    # Test that the binary runs and returns version
+    assert_match "Peekaboo", shell_output("#{bin}/peekaboo --version")
+
+    # Test help command
+    assert_match "USAGE:", shell_output("#{bin}/peekaboo --help")
+  end
+end


### PR DESCRIPTION
Seed Peekaboo in `openclaw/tap` so its 4.3.1 release can dispatch the existing formula-update workflow. The template points to the already-published 4.3.0 signed universal archive and keeps the adjacent Swift compatibility libraries required by the executable. The workflow will replace the version, URL, and checksum with 4.3.1 after publication.

The generic updater creates a four-platform formula when none exists; Peekaboo is a macOS-only universal CLI, so it needs this explicit seed first. The menu-bar app remains the separately installed DMG from GitHub Releases.

Validation: the formula passes `brew style`; its 4.3.0 archive URL and SHA-256 match the installed release formula. The exact template was included in the Peekaboo release-preparation autoreview, clean through P2. The seed removes redundant executable chmod, which current Homebrew no longer accepts as `post_install`.

Please land before the Peekaboo 4.3.1 release is published. Release installation verification will run the resulting 4.3.1 formula and CLI.
