### PR TITLE
goplaces: remove deprecated postflight hook

### DIFF
--- a/Casks/goplaces.rb
+++ b/Casks/goplaces.rb
@@ -34,12 +34,6 @@ cask "goplaces" do
 
   binary "goplaces"
 
-  postflight do
-    if OS.mac?
-      system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/goplaces"]
-    end
-  end
-
   # No zap stanza required
 
 end


### PR DESCRIPTION
Removes Goplaces' deprecated `postflight` hook, eliminating the Homebrew warning and preserving `com.apple.quarantine` as required by the upstream release guide. The published 0.4.9 binaries are already signed and notarized; their version, download URLs, checksums, and binary install stanza remain unchanged.

Maintainer validation at `1e30b58c6dab4a93c341a02f07658344786accc4`:

- Homebrew 6.0.22: fresh installation and a real upgrade from the published 0.4.4 cask to this 0.4.9 cask succeeded for both Darwin ARM64 and AMD64 archives. Testing ran on macOS ARM64; AMD64 execution used Rosetta.
- The harness used Homebrew's real `Cask::Installer` and `Cask::Upgrade.upgrade_cask`, redirecting only Caskroom, binary links, cache, and temporary paths to task-owned directories. Download checksums, extraction, quarantine, installation, and upgrade behavior were unchanged. Existing user installations were untouched.
- Each installed binary matched its release archive member byte for byte, passed `codesign --verify --strict --check-notarization --verbose=2`, printed `0.4.9` with `--version`, and retained quarantine before and after launch. No ad-hoc signing or quarantine removal was used on the candidate.
- Loading the old cask emits the `postflight` deprecation; loading the candidate emits none. The upstream generator no longer contains this hook.
- All 67 tests and Homebrew formula style passed on the PR head. CI passed: https://github.com/openclaw/homebrew-tap/actions/runs/34038286520. Isolated Codex autoreview was clean through P2.

`spctl --assess --type execute` reported “the code is valid but does not seem to be an app” for the standalone CLI. Notarization was verified with `codesign --check-notarization`, and the actual quarantined executable launched successfully; this is not a claim of a successful `spctl` app assessment or native Intel-host testing.

The changelog credit is reserved for the separate notes PR, which should merge last.
