### PR TITLE
feat(ocm): add signed binary formula and install checks

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -387,11 +387,11 @@ def parse_target_aliases(value: str | None) -> dict[str, str]:
 def target_markers(target: str, alias: str | None = None) -> tuple[str, ...]:
     markers = {target, target.replace("_", "-")}
     if target == "darwin_amd64":
-        markers.update(("macos-x86_64", "macos-amd64", "darwin-x86_64"))
+        markers.update(("macos-x86_64", "macos-amd64", "darwin-x86_64", "x86_64-apple-darwin"))
     elif target == "darwin_arm64":
-        markers.update(("macos-arm64", "darwin-aarch64"))
+        markers.update(("macos-arm64", "darwin-aarch64", "aarch64-apple-darwin"))
     elif target == "linux_amd64":
-        markers.update(("linux-x86_64", "linux-amd64"))
+        markers.update(("linux-x86_64", "linux-amd64", "x86_64-unknown-linux-gnu"))
     elif target == "linux_arm64":
         markers.update(("linux-aarch64", "linux-arm64"))
     elif target == "darwin_universal":

--- a/.github/workflows/ocm-smoke.yml
+++ b/.github/workflows/ocm-smoke.yml
@@ -1,0 +1,48 @@
+name: OCM Install
+
+on:
+  pull_request:
+    paths:
+      - Formula/ocm.rb
+      - .github/scripts/update_formula.py
+      - .github/scripts/reconcile_formulae.py
+      - .github/workflows/ocm-smoke.yml
+      - tests/smoke_ocm.sh
+  push:
+    branches:
+      - main
+    paths:
+      - Formula/ocm.rb
+      - .github/scripts/update_formula.py
+      - .github/scripts/reconcile_formulae.py
+      - .github/workflows/ocm-smoke.yml
+      - tests/smoke_ocm.sh
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: OCM install (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x86_64
+          - runner: ubuntu-24.04
+            arch: x86_64
+    steps:
+      - name: Checkout tap repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install and test the checked-out OCM formula
+        env:
+          EXPECTED_ARCH: ${{ matrix.arch }}
+        run: bash tests/smoke_ocm.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Highlights:** Release updates fail cleanly without publishing partial or placeholder formulae, while preserving supported legacy layouts.
 
+- Add OCM v0.2.39 for macOS ARM64/Intel and Linux x86_64, preserving signed release binaries, reconciling Rust-target archives, and testing installed packages on all three platforms. Use `brew upgrade openclaw/tap/ocm`; this initial binary does not guard against self-update.
 - Reject unrecognized release assets before partial updates while preserving smaller legacy target inventories and resources; thanks @SebTardif.
 - Keep Linux source-archive URLs and checksums in sync during multi-target updates; thanks @SebTardif.
 - Leave no zero-checksum formula behind when a new formula download fails; thanks @SebTardif.

--- a/Formula/ocm.rb
+++ b/Formula/ocm.rb
@@ -1,0 +1,50 @@
+class Ocm < Formula
+  desc "Manage isolated OpenClaw environments, runtimes, and services"
+  homepage "https://github.com/openclaw/ocm"
+  version "0.2.39"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/openclaw/ocm/releases/download/v0.2.39/ocm-aarch64-apple-darwin.tar.gz"
+      sha256 "a8c9700227bee9ed9264251512e75a4b434700cb4b2cd9a5bcac2b56fde25f39"
+    end
+    on_intel do
+      url "https://github.com/openclaw/ocm/releases/download/v0.2.39/ocm-x86_64-apple-darwin.tar.gz"
+      sha256 "6f221625ff54f62495bc61c8ab4f81e66ddecf079167a37548c1fe1a4da76034"
+    end
+  end
+
+  on_linux do
+    depends_on arch: :x86_64
+
+    on_intel do
+      url "https://github.com/openclaw/ocm/releases/download/v0.2.39/ocm-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "e34a5e1b7f8cfab011ebb3b81fd661da2ec71e427084da756fa3bde61f5a4d9a"
+    end
+  end
+
+  skip_clean "bin/ocm"
+
+  def install
+    bin.install "ocm"
+  end
+
+  def caveats
+    <<~EOS
+      Update this Homebrew installation with:
+        brew upgrade openclaw/tap/ocm
+      Do not run `ocm self update` on this installation.
+      OCM v0.2.39 does not prevent self-update from replacing a Homebrew-managed binary.
+    EOS
+  end
+
+  test do
+    assert_match "ocm #{version}", shell_output("#{bin}/ocm --version")
+    assert_match "ocm", shell_output("#{bin}/ocm --help")
+    if OS.mac?
+      system "/usr/bin/codesign", "--verify", "--strict", bin/"ocm"
+      assert_match "anchor apple generic", shell_output("/usr/bin/codesign -d -r- #{bin}/ocm 2>&1")
+    end
+  end
+end

--- a/Formula/ocm.rb
+++ b/Formula/ocm.rb
@@ -40,7 +40,7 @@ class Ocm < Formula
   end
 
   test do
-    assert_match "ocm #{version}", shell_output("#{bin}/ocm --version")
+    assert_equal "#{version}\n", shell_output("#{bin}/ocm --version")
     assert_match "ocm", shell_output("#{bin}/ocm --help")
     if OS.mac?
       system "/usr/bin/codesign", "--verify", "--strict", bin/"ocm"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ brew install --cask openclaw/tap/<name>
 - `gogcli` — Google CLI for Gmail, Calendar, Drive, Docs, Sheets, and more
 - `graincrawl` — Local-first Granola crawler into SQLite and Markdown
 - `notcrawl` — Local-first Notion crawler into SQLite and normalized Markdown
+- `ocm` — Manage isolated OpenClaw environments, runtimes, and services
 - `octopool` — Org-authenticated GitHub read relay and gh-compatible cache shim
 - `slacrawl` — Go-based CLI for mirroring Slack workspace data into local SQLite
 - `telecrawl` — Telegram Desktop archive CLI with encrypted Git backups
@@ -60,6 +61,9 @@ brew uninstall --cask --zap openclaw/tap/<name>
 ## Notes
 
 - Run `brew info openclaw/tap/<name>` for per-tool caveats (permissions, setup steps, etc.).
+- OCM supports macOS Apple Silicon/Intel and Linux x86_64. Install with
+  `brew install openclaw/tap/ocm` and update with `brew upgrade openclaw/tap/ocm`,
+  not `ocm self update`. The initial v0.2.39 binary has no Homebrew self-update guard.
 
 ## Maintainers
 
@@ -102,6 +106,12 @@ It never downgrades, skips drafts and prereleases, and makes no commit when ever
 current. Manual reconciles default to dry-run and can target one formula. The reconciler reads public
 release metadata and pushes with this tap's own `GITHUB_TOKEN`; it needs no cross-repository token or
 other external credential. The dispatch path remains the preferred low-latency path.
+
+OCM uses reconciliation directly: its three Rust-target archives are discovered from the
+formula, without a cross-repository dispatch token or a Linux ARM64 artifact. Installation
+preserves the published executable bytes, including the macOS Developer ID signature.
+Changes to the OCM formula or its updater run installed-Homebrew tests on macOS ARM64,
+macOS x86_64, and Linux x86_64, using the checked-out formula rather than the public tap.
 
 Pull requests and updates to `main` run the updater and reconciler tests and validate every formula's
 Ruby syntax.

--- a/tests/smoke_ocm.sh
+++ b/tests/smoke_ocm.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${GITHUB_ACTIONS:-}" != "true" || "${RUNNER_ENVIRONMENT:-}" != "github-hosted" ]]; then
+  echo "This install smoke runs only on disposable GitHub-hosted runners." >&2
+  exit 1
+fi
+
+[[ "$(uname -m)" == "$EXPECTED_ARCH" ]]
+export HOME="$RUNNER_TEMP/ocm-home"
+export OCM_HOME="$RUNNER_TEMP/ocm-state"
+export HOMEBREW_CACHE="$RUNNER_TEMP/ocm-brew-cache"
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+export HOMEBREW_NO_ANALYTICS=1
+mkdir -p "$HOME" "$OCM_HOME"
+if [[ "$RUNNER_OS" == "Linux" ]]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+
+# Clone the PR checkout, not the public tap's default branch.
+formula="openclaw/tap/ocm"
+brew tap --custom-remote openclaw/tap "$GITHUB_WORKSPACE"
+tap="$(brew --repository openclaw/tap)"
+[[ "$(git -C "$tap" rev-parse HEAD)" == "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" ]]
+cmp "$GITHUB_WORKSPACE/Formula/ocm.rb" "$tap/Formula/ocm.rb"
+brew install --formula "$formula"
+brew test "$formula"
+
+metadata="$RUNNER_TEMP/ocm-brew-info.json"
+brew info --json=v2 "$formula" > "$metadata"
+version="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["formulae"][0]["versions"]["stable"])' "$metadata")"
+keg="$(brew --cellar "$formula")/$version"
+binary="$keg/bin/ocm"
+python3 - "$metadata" "$keg/INSTALL_RECEIPT.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as handle:
+    formula = json.load(handle)["formulae"][0]
+with open(sys.argv[2]) as handle:
+    receipt = json.load(handle)
+assert any(item["version"] == formula["versions"]["stable"] for item in formula["installed"])
+assert receipt["source"]["tap"] == "openclaw/tap"
+PY
+[[ "$("$binary" --version)" == "ocm $version" ]]
+"$binary" --help
+
+payload="$RUNNER_TEMP/ocm-release-payload"
+mkdir -p "$payload"
+tar -xzf "$(brew --cache "$formula")" -C "$payload"
+cmp "$payload/ocm" "$binary"
+file "$binary"
+if [[ "$RUNNER_OS" == "macOS" ]]; then
+  [[ "$(lipo -archs "$binary")" == "$EXPECTED_ARCH" ]]
+  otool -L "$binary"
+  codesign --verify --strict --verbose=2 "$binary"
+  codesign --verify --strict --verbose=2 --check-notarization --test-requirement '=notarized' "$binary"
+else
+  file "$binary" | grep -F "x86-64"
+  ldd "$binary" > "$RUNNER_TEMP/ocm-linked-libraries.txt"
+  cat "$RUNNER_TEMP/ocm-linked-libraries.txt"
+  if grep -F "not found" "$RUNNER_TEMP/ocm-linked-libraries.txt"; then
+    exit 1
+  fi
+fi

--- a/tests/smoke_ocm.sh
+++ b/tests/smoke_ocm.sh
@@ -43,7 +43,7 @@ with open(sys.argv[2]) as handle:
 assert any(item["version"] == formula["versions"]["stable"] for item in formula["installed"])
 assert receipt["source"]["tap"] == "openclaw/tap"
 PY
-[[ "$("$binary" --version)" == "ocm $version" ]]
+[[ "$("$binary" --version)" == "$version" ]]
 "$binary" --help
 
 payload="$RUNNER_TEMP/ocm-release-payload"

--- a/tests/test_reconcile_formulae.py
+++ b/tests/test_reconcile_formulae.py
@@ -88,6 +88,75 @@ class ReconcileFormulaeTest(unittest.TestCase):
                 self.assertEqual(info.name, path.stem)
                 self.assertTrue(info.update_options)
 
+    def test_ocm_reconciliation_preserves_three_targets_and_installed_binary_policy(self) -> None:
+        original = (ROOT / "Formula" / "ocm.rb").read_text()
+        info = reconcile_formulae.parse_formula(ROOT / "Formula" / "ocm.rb")
+        newer = f"v{info.current_version.major}.{info.current_version.minor + 1}.0"
+        targets = ("aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu")
+        urls = [
+            f"https://github.com/openclaw/ocm/releases/download/{newer}/ocm-{target}.tar.gz"
+            for target in targets
+        ]
+        expected = original.replace(f'version "{info.current_tag[1:]}"', f'version "{newer[1:]}"')
+        for pair in reconcile_formulae.update_formula.iter_url_sha_pairs(original):
+            url = pair.group("url").replace(f"/{info.current_tag}/", f"/{newer}/")
+            self.assertIn(url, urls)
+            expected = expected.replace(pair.group("url"), url).replace(
+                pair.group("sha"), hashlib.sha256(url.encode()).hexdigest(),
+            )
+
+        for dry_run in (False, True):
+            for failed_download in (False, True):
+                with self.subTest(dry_run=dry_run, failed_download=failed_download):
+                    directory, root = self.make_tap()
+                    self.addCleanup(directory.cleanup)
+                    ocm = root / "Formula" / "ocm.rb"
+                    ocm.write_text(original)
+                    downloads = []
+
+                    def response(request, **kwargs):
+                        url = request.full_url
+                        if url == "https://api.github.com/repos/openclaw/ocm/releases/latest":
+                            return io.BytesIO(json.dumps({"tag_name": newer}).encode())
+                        if url == "https://api.github.com/repos/openclaw/example/releases/latest":
+                            return io.BytesIO(b'{"tag_name":"v1.2.3"}')
+                        self.assertIn(url, urls)
+                        downloads.append(url)
+                        if failed_download and url == urls[-1]:
+                            raise reconcile_formulae.urllib.error.URLError("fixture download failed")
+                        return io.BytesIO(url.encode())
+
+                    def run(command, *, cwd, check):
+                        self.assertTrue(check)
+                        self.assertEqual(pathlib.Path(command[1]).name, "update_formula.py")
+                        previous_directory = pathlib.Path.cwd()
+                        os.chdir(cwd)
+                        try:
+                            self.assertEqual(reconcile_formulae.update_formula.main(command[2:]), 0)
+                        finally:
+                            os.chdir(previous_directory)
+
+                    output = io.StringIO()
+                    with (
+                        mock.patch.object(reconcile_formulae.urllib.request, "urlopen", side_effect=response),
+                        mock.patch.object(reconcile_formulae.subprocess, "run", side_effect=run),
+                        contextlib.redirect_stdout(output),
+                    ):
+                        summary = reconcile_formulae.reconcile(root, None, dry_run)
+                    self.assertCountEqual(downloads, urls)
+                    self.assertEqual(summary, reconcile_formulae.Summary(
+                        scanned=2, current=1, drift=1,
+                        updated=0 if failed_download else 1,
+                        failed=1 if failed_download else 0,
+                    ))
+                    self.assertEqual(ocm.read_text(), original if dry_run or failed_download else expected)
+                    self.assertEqual((root / "Formula" / "example.rb").read_text(), formula_text())
+                    if dry_run and not failed_download:
+                        self.assertIn("WOULD UPDATE ocm", output.getvalue())
+                        for line in expected.splitlines():
+                            if line.strip().startswith(('url "', 'sha256 "', 'version "')):
+                                self.assertIn("+" + line, output.getvalue())
+
     def test_crabbox_reconciliation_uses_published_stable_releases_in_all_scan_modes(self) -> None:
         original = (ROOT / "Formula" / "crabbox.rb").read_text()
         info = reconcile_formulae.parse_formula(ROOT / "Formula" / "crabbox.rb")


### PR DESCRIPTION
## What Problem This Solves

OCM has signed GitHub release binaries, but no formula in this tap. Its Rust target filenames are also not recognized by the existing release reconciler.

## Solution

- Add `openclaw/tap/ocm` for the existing v0.2.39 release: macOS ARM64, macOS x86_64, and Linux x86_64 only.
- Install the published executable directly and preserve its bytes with `skip_clean`; verify the installed macOS signature.
- Recognize the three Rust target triples so the existing three-hour reconciler can update OCM using the tap's own token.
- Keep the four-platform `assets` and `verified-hashes-v1` contracts unchanged.
- Add a path-scoped, three-platform hosted install matrix that uses the checked-out formula, isolated user state, Brew receipts, architecture checks, and release-to-keg byte comparisons. macOS also checks notarization.

## User Impact

Install with `brew install openclaw/tap/ocm`; update with `brew upgrade openclaw/tap/ocm`.

The v0.2.39 binary does not guard against overwriting a Homebrew-managed executable through `ocm self update`. The formula and README explicitly warn against using that command. This PR does not patch or rebuild that release, start services, add credentials, or publish a new OCM release.

The future in-binary Homebrew guard and crate publishing setup are tracked separately in https://github.com/openclaw/ocm/pull/157.

## Evidence

- All three archive hashes match the audited release bytes, published `SHA256SUMS`, and revalidated GitHub asset digests.
- The new reconciliation regression failed before Rust filename recognition and passes after it. It exercises the real updater, exactly three downloads, new hashes, preserved formula content and neighboring formula, dry-run behavior, and no partial write on download failure.
- All 68 Python tests pass with Python 3.13.
- All 17 formulae pass Ruby syntax and Homebrew style checks.
- Actionlint, shellcheck, shell syntax, and `git diff --check` pass.
- A live OCM reconciliation dry-run reports v0.2.39 current with no writes.
- Independent P2 review found no actionable issues.
- [Hosted install checks](https://github.com/openclaw/homebrew-tap/actions/runs/34074529061) pass on head `a26c25a55af68a87bc68ef4198d5e1c77f1d6d78`: macOS ARM64, macOS x86_64, and Linux x86_64. Each installed from the PR checkout and passed `brew test`, exact version/help, receipt, architecture, and release-to-keg byte checks. Both Macs also passed signature and notarization verification.
- [CI](https://github.com/openclaw/homebrew-tap/actions/runs/34074529062) and [managed CodeQL](https://github.com/openclaw/homebrew-tap/actions/runs/34074527057) pass on the same head.
- The initial hosted run exposed an incorrect version-output assertion. The released CLI prints only `0.2.39`; both checks now require that exact output.
