### PR TITLE
feat(clawdex): add verified 0.2.1 formula

### DIFF
--- a/Formula/clawdex.rb
+++ b/Formula/clawdex.rb
@@ -1,0 +1,36 @@
+class Clawdex < Formula
+  desc "Local-first address book backed by Markdown"
+  homepage "https://github.com/openclaw/clawdex"
+  version "0.2.1"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/openclaw/clawdex/releases/download/v0.2.1/clawdex_0.2.1_darwin_arm64.tar.gz"
+      sha256 "eb046367457a5f0288a7f1d96d41c611a258991734ef485a079c6e3fc36c5d3a"
+    else
+      url "https://github.com/openclaw/clawdex/releases/download/v0.2.1/clawdex_0.2.1_darwin_amd64.tar.gz"
+      sha256 "ebd53458552e0ffbef52682c55a42020920b970b5bf24aa0a957f1e49c3c8029"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/openclaw/clawdex/releases/download/v0.2.1/clawdex_0.2.1_linux_arm64.tar.gz"
+      sha256 "e9bc25fa223522607d5bd33581be207781a3850e89c057871b5ef3e9277a57a7"
+    else
+      url "https://github.com/openclaw/clawdex/releases/download/v0.2.1/clawdex_0.2.1_linux_amd64.tar.gz"
+      sha256 "d1efb3d4e9b51d81faf79df597a2373f52994bf99270778f6cc4da77926c5933"
+    end
+  end
+
+  skip_clean "bin/clawdex"
+
+  def install
+    bin.install "clawdex"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/clawdex --version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ brew install --cask openclaw/tap/<name>
 
 - `axorc` — Inspect and automate macOS Accessibility from the shell
 - `clawscan` — Agent-skill security scanner harness for ClawHub
+- `clawdex` — Local-first address book backed by Markdown
 - `crabbox` — Remote Linux test boxes for dirty worktrees and CI hydration
 - `crabfleet` — Fleet management CLI for Crabbox workers
 - `crawlbar` — macOS menu bar control plane for local-first crawler CLIs


### PR DESCRIPTION
Clawdex 0.2.1 is published, but its first Homebrew handoff failed because the generated description, `clawdex command-line tool`, violates Homebrew description rules. Seed the maintained formula with a valid description and the four exact Darwin/Linux archive URLs and SHA-256 hashes from the verified release inventory. Preserve the signed executable during cleanup and list the package in the README.

Release: https://github.com/openclaw/clawdex/releases/tag/v0.2.1
Failed tap run: https://github.com/openclaw/homebrew-tap/actions/runs/34075397188

Validation:
- The updater independently downloaded and verified all four public release archives against the release inventory.
- All 68 updater/reconciler tests passed; Ruby syntax passed; `brew style Formula/clawdex.rb` reported no offenses.
- Executed the actual Homebrew formula download/install method in an isolated prefix. The installed binary matched the archive bytes, passed online notarization verification, and printed `0.2.1`.
- Independent autoreview through P2 was clean with current publication/download evidence.

After this lands, rerun the Homebrew handoff job in the existing Clawdex release run: https://github.com/openclaw/clawdex/actions/runs/34075120531 . No rebuild, signing, tagging, or republication is needed. The existing public tap install remains unavailable until this formula lands.
