### PR TITLE
docs: refresh tap package guide and unreleased notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
-**Highlights:** Release updates fail cleanly without publishing partial or placeholder formulae, while preserving supported legacy layouts.
+**Highlights:** Install OCM and Peekaboo from the tap, keep Goplaces quarantine protection, and recover release updates without publishing partial formulae.
 
 - Add OCM v0.2.39 for macOS ARM64/Intel and Linux x86_64, preserving signed release binaries, reconciling Rust-target archives, and testing installed packages on all three platforms. Use `brew upgrade openclaw/tap/ocm`; this initial binary does not guard against self-update.
+- Add the Peekaboo 4.3.1 universal macOS formula and list it in the package guide.
+- Remove the deprecated Goplaces postflight hook, preserving quarantine on signed, notarized binaries and eliminating Homebrew's warning; thanks @karbo-hub.
+- Automatically reconcile formulae with their latest stable source releases every three hours without downgrading or selecting drafts and prereleases.
 - Reject unrecognized release assets before partial updates while preserving smaller legacy target inventories and resources; thanks @SebTardif.
 - Keep Linux source-archive URLs and checksums in sync during multi-target updates; thanks @SebTardif.
 - Leave no zero-checksum formula behind when a new formula download fails; thanks @SebTardif.
@@ -13,9 +16,8 @@
 - Stop stalled source-tag Git fetches and lookups after 60 seconds; thanks @SebTardif.
 - Update the `slacrawl` formula to 0.8.7 with verified macOS and Linux archives for Intel and ARM.
 - Update the `goplaces` cask to 0.4.9 with the `--radius` alias and signed, notarized macOS binaries.
-- Automatically reconcile formulae with their latest stable source releases every three hours without downgrading or selecting drafts and prereleases.
 - Preserve formula-owned install instructions and caveats while accepting exact four-platform release asset inventories and verified source-tag provenance.
 - Align Crabbox tap updates with published releases and downloaded checksums, with reconciliation as a recovery path.
 - Validate release-dispatch inputs and require protected-default-branch execution for formula automation.
 - Correct Gitcrawl configuration paths and direct GitHub shim users to Octopool.
-- Provide Homebrew formulae for axorc, clawscan, crabbox, crabfleet, crawlbar, discrawl, gitcrawl, gogcli, graincrawl, notcrawl, octopool, slacrawl, telecrawl, wacli, and wacrawl, plus the Goplaces cask.
+- Provide Homebrew formulae for axorc, clawscan, clawdex, crabbox, crabfleet, crawlbar, discrawl, gitcrawl, gogcli, graincrawl, notcrawl, octopool, slacrawl, telecrawl, wacli, and wacrawl, plus the Goplaces cask.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ brew install --cask openclaw/tap/<name>
 - `notcrawl` — Local-first Notion crawler into SQLite and normalized Markdown
 - `ocm` — Manage isolated OpenClaw environments, runtimes, and services
 - `octopool` — Org-authenticated GitHub read relay and gh-compatible cache shim
+- `peekaboo` — Capture macOS screenshots and automate the desktop
 - `slacrawl` — Go-based CLI for mirroring Slack workspace data into local SQLite
 - `telecrawl` — Telegram Desktop archive CLI with encrypted Git backups
 - `wacli` — WhatsApp CLI built on whatsmeow


### PR DESCRIPTION
The package guide omitted the already-shipped Peekaboo formula, and Unreleased lacked its entry, Clawdex's package coverage, and the Goplaces cask fix prepared in #36. Add the missing package documentation and consolidate the notes with a short Highlights lead-in and contributor credit.

Merge **after #36**. This branch is independently based on main and contains only README/CHANGELOG changes; #36 contains only its cask change, so the two PRs do not conflict. #31 remains outside these notes pending a decision on supported artifact-source policy.

Validation:

- Package guide matches all 18 checked-in formulae; exactly one Unreleased section; `git diff --check` passes.
- Current main's unchanged code passes all 68 tests, syntax validation for 19 Ruby package files, and Homebrew style for all 18 formulae.
- Real `reconcile_formulae.py --dry-run`: 18 current, zero drift, zero failures, no writes.
- All formulae and the Goplaces cask are current. Both pinned Actions match their latest published releases and commit IDs: checkout 7.0.1 and create-github-app-token 3.2.0. No dependency bump is necessary.
- Isolated Codex pre-commit and committed-branch autoreviews are both clean through P2.

No tap version release is proposed: this repository has no tags or GitHub Releases and distributes package updates through Homebrew's normal Git tap channel.
