### PR TITLE
chore(ocm): update signed binaries to 0.2.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Highlights:** Install OCM and Peekaboo from the tap, keep Goplaces quarantine protection, and recover release updates without publishing partial formulae.
 
-- Add OCM v0.2.39 for macOS ARM64/Intel and Linux x86_64, preserving signed release binaries, reconciling Rust-target archives, and testing installed packages on all three platforms. Use `brew upgrade openclaw/tap/ocm`; this initial binary does not guard against self-update.
+- Update OCM to v0.2.40 for macOS ARM64/Intel and Linux x86_64, preserving signed release binaries and testing installed packages on all three platforms. Use `brew upgrade openclaw/tap/ocm`; self-update now refuses to replace Homebrew-managed binaries.
 - Add the Peekaboo 4.3.1 universal macOS formula and list it in the package guide.
 - Remove the deprecated Goplaces postflight hook, preserving quarantine on signed, notarized binaries and eliminating Homebrew's warning; thanks @karbo-hub.
 - Validate every checksum-download redirect before following it, rejecting HTTPS downgrades, credentials, and fragments while preserving the existing host contract; thanks @SebTardif.

--- a/Formula/ocm.rb
+++ b/Formula/ocm.rb
@@ -1,17 +1,17 @@
 class Ocm < Formula
   desc "Manage isolated OpenClaw environments, runtimes, and services"
   homepage "https://github.com/openclaw/ocm"
-  version "0.2.39"
+  version "0.2.40"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/openclaw/ocm/releases/download/v0.2.39/ocm-aarch64-apple-darwin.tar.gz"
-      sha256 "a8c9700227bee9ed9264251512e75a4b434700cb4b2cd9a5bcac2b56fde25f39"
+      url "https://github.com/openclaw/ocm/releases/download/v0.2.40/ocm-aarch64-apple-darwin.tar.gz"
+      sha256 "9ac67161b3345e3a85e5ce0a7412cba304c9aa30cae0580e34d894b307f7ad9c"
     end
     on_intel do
-      url "https://github.com/openclaw/ocm/releases/download/v0.2.39/ocm-x86_64-apple-darwin.tar.gz"
-      sha256 "6f221625ff54f62495bc61c8ab4f81e66ddecf079167a37548c1fe1a4da76034"
+      url "https://github.com/openclaw/ocm/releases/download/v0.2.40/ocm-x86_64-apple-darwin.tar.gz"
+      sha256 "97772432e8a4a379d96b439faa041bcdca1098f8015222186d6c34fbb06e0de3"
     end
   end
 
@@ -19,8 +19,8 @@ class Ocm < Formula
     depends_on arch: :x86_64
 
     on_intel do
-      url "https://github.com/openclaw/ocm/releases/download/v0.2.39/ocm-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "e34a5e1b7f8cfab011ebb3b81fd661da2ec71e427084da756fa3bde61f5a4d9a"
+      url "https://github.com/openclaw/ocm/releases/download/v0.2.40/ocm-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "d6236c33040af859ff79aac09fbf5f00098e7bda09b009d26bf7360d5eb82e12"
     end
   end
 
@@ -35,7 +35,6 @@ class Ocm < Formula
       Update this Homebrew installation with:
         brew upgrade openclaw/tap/ocm
       Do not run `ocm self update` on this installation.
-      OCM v0.2.39 does not prevent self-update from replacing a Homebrew-managed binary.
     EOS
   end
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ brew uninstall --cask --zap openclaw/tap/<name>
 - Run `brew info openclaw/tap/<name>` for per-tool caveats (permissions, setup steps, etc.).
 - OCM supports macOS Apple Silicon/Intel and Linux x86_64. Install with
   `brew install openclaw/tap/ocm` and update with `brew upgrade openclaw/tap/ocm`,
-  not `ocm self update`. The initial v0.2.39 binary has no Homebrew self-update guard.
+  not `ocm self update`, which refuses to replace Homebrew-managed binaries.
 
 ## Maintainers
 


### PR DESCRIPTION
## What Problem This Solves

The tap still installs OCM 0.2.39, which predates the native guard against replacing Homebrew-managed binaries through self-update.

## Why This Change Was Made

Update only OCM to the published, signed v0.2.40 release and remove its obsolete v0.2.39 caveats. Keep the existing three-platform inventory and signature-preserving installation unchanged.

The scoped reconciler's archive download timed out without changing any files. The exact public assets were downloaded with the GitHub CLI, checked against the original `SHA256SUMS` and GitHub asset digests, then their verified URLs/checksums were applied directly. No updater or timeout changes are included.

## User Impact

`brew upgrade openclaw/tap/ocm` installs OCM 0.2.40. `ocm self update` refuses to replace a Homebrew-owned executable and directs upgrades back to Homebrew.

## Evidence

- Published release: https://github.com/openclaw/ocm/releases/tag/v0.2.40
- Release workflow passed all three native builds and both macOS signing/notarization checks: https://github.com/openclaw/ocm/actions/runs/34113168186
- Signed tag target: `b5ad5667834f801fb9dff860b92e5d05ffd468a1`.
- All downloaded archives match both original release checksums and GitHub asset digests.
- 73 updater tests passed; Ruby syntax and `git diff --check` passed.
- Independent review through P2: scoped-clean.
- Hosted updater tests, Ruby syntax, and Homebrew style passed on exact head `6680b50e378ed6b41ce3fe4bdb0e748cc99e0fd6`: https://github.com/openclaw/homebrew-tap/actions/runs/34114033489
- Installed-Brew checks passed on Apple Silicon, Intel Mac, and Linux, including native version, installed-byte verification, and macOS signing/notarization: https://github.com/openclaw/homebrew-tap/actions/runs/34114033552
- Local formula-mode style checking requires a registered tap; generic file mode collided with the unrelated Homebrew-core `ocm` class. The unchanged hosted style gate passed in its proper tap context.

## Review Disposition

The review found no introduced formula defect. Its upstream-fetch limitation is covered by the verified release/tag/assets above and direct inspection of [the released ownership guard](https://github.com/openclaw/ocm/blob/b5ad5667834f801fb9dff860b92e5d05ffd468a1/src/cli/self_cmd.rs#L211).

The existing `homebrew_self_update_preserves_the_keg_and_allows_checks_through_symlinks` integration test passed on Linux and macOS in [exact-source main CI](https://github.com/openclaw/ocm/actions/runs/34112531886). Additionally, the original published ARM binary was executed in an isolated receipt/symlink fixture: both direct-keg and symlink invocations of `self update --raw` exited 1 with Homebrew upgrade guidance, and its SHA256 remained `ad8ff560fa29fc9987b6dfe75367d07bf773878b37c0ced62e314257389578d5`.

A full existing-installation `brew upgrade` from 0.2.39 was not separately run. The narrow formula update is accepted on the three actual installed-Brew platform checks, verified release provenance, unchanged installation/linking contract, and guard evidence above. No custom migration, upgrade hook, platform, or installer change is introduced.
