### PR TITLE
test: require TLS 1.2 for redirect fixtures

### DIFF
--- a/tests/test_download_redirects.py
+++ b/tests/test_download_redirects.py
@@ -43,6 +43,7 @@ class DownloadRedirectTest(unittest.TestCase):
             check=True, capture_output=True, timeout=30,
         )
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         context.load_cert_chain(cls.certificate, key)
         cls.payload = b"release archive through verified TLS\n"
         cls.requests: list[tuple[str, str]] = []


### PR DESCRIPTION
## Summary

Set the loopback HTTPS redirect fixture's explicit minimum protocol to TLS 1.2
immediately after constructing its server SSL context.

This addresses https://github.com/openclaw/homebrew-tap/security/code-scanning/1
without changing production downloads, redirect policy, certificate verification,
fixture assertions, workflows, or dependencies.

## Validation

- Exact one-line change in `tests/test_download_redirects.py`.
- `git diff --check` passed.
- With Python 3.13.15 linked to OpenSSL 3.6.3,
  all five existing tests passed once on the clean base and once after.
  Command: `python3.13 -B -m unittest discover -s tests -p test_download_redirects.py -v`.
  Default verification flags remained `557088`; no trust, certificate, or
  environment workaround was used.
- Historical local runs on Python 3.9.6 linked to LibreSSL 2.8.3 failed before
  and after with the same one failure and 15 subtest errors, beginning at
  self-signed certificate rejection. Those failed receipts remain preserved.
- Fixture certificate generator: OpenSSL 3.6.3.

## Hosted Checks

On reviewed head `df0046c057da407b8974e406558614a03d77b690`:

- CI passed: https://github.com/openclaw/homebrew-tap/actions/runs/34130341118.
- CodeQL analyses passed:
  https://github.com/openclaw/homebrew-tap/actions/runs/34130338427.
- ClawSweeper completed its exact-head review with no actionable findings or
  before-merge items:
  https://github.com/openclaw/homebrew-tap/pull/41#issuecomment-5571771054.

The local Python 3.13 results and hosted CI are separate evidence; the historical
LibreSSL limitation above remains recorded.
No certificate-validation bypass, runtime installation, or test relaxation was
used.
