### PR TITLE
fix(peekaboo): match the v4 help header in the smoke test

### DIFF
--- a/Formula/peekaboo.rb
+++ b/Formula/peekaboo.rb
@@ -34,6 +34,6 @@ class Peekaboo < Formula
     assert_match "Peekaboo", shell_output("#{bin}/peekaboo --version")
 
     # Test help command
-    assert_match "USAGE:", shell_output("#{bin}/peekaboo --help")
+    assert_match(/\AUsage\n\s+peekaboo\b/, shell_output("#{bin}/peekaboo --help"))
   end
 end


### PR DESCRIPTION
`brew test openclaw/tap/peekaboo` fails on 4.3.2 because the smoke test still expects the old `USAGE:` header; Peekaboo v4 prints `Usage` followed by the indented command name. Anchor the assertion on that real header instead.

Verified the anchored assertion against the installed 4.3.2 tap binary during the 4.3.2 release verification. The same fix lands in Peekaboo's formula template so the next handoff does not regress it.
