### PR TITLE
fix(ocm): keep tap valid on unsupported architectures

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -425,7 +425,9 @@ def classify_target(url: str, aliases: dict[str, str], version: str) -> str | No
 def iter_url_sha_pairs(text: str) -> list[re.Match[str]]:
     return list(
         re.finditer(
-            r'(?P<prefix>url ")(?P<url>[^"]+)(?P<middle>"\n\s+sha256 ")(?P<sha>[0-9a-f]+)(?P<suffix>")',
+            r'(?P<prefix>url ")(?P<url>[^"]+)'
+            r'(?P<middle>"\n(?:[ \t]+version "[^"\n]+"\n)?\s+sha256 ")'
+            r'(?P<sha>[0-9a-f]+)(?P<suffix>")',
             text,
             flags=re.MULTILINE,
         )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,11 @@ jobs:
 
       - name: Validate Homebrew style
         run: brew style Formula/*.rb
+
+      - name: Validate tap on every Homebrew platform
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          brew tap --custom-remote openclaw/tap "$GITHUB_WORKSPACE"
+          brew readall --os=all --arch=all openclaw/tap
+          brew ruby tests/test_ocm_platforms.rb

--- a/Formula/ocm.rb
+++ b/Formula/ocm.rb
@@ -1,7 +1,9 @@
 class Ocm < Formula
   desc "Manage isolated OpenClaw environments, runtimes, and services"
   homepage "https://github.com/openclaw/ocm"
+  url "https://github.com/openclaw/ocm/releases/download/v0.2.41/ocm-x86_64-unknown-linux-gnu.tar.gz"
   version "0.2.41"
+  sha256 "e57dc642d70310f8bf19096c0fc41aab0325c8fab24b9ed0c6367c60a02b6198"
   license "MIT"
 
   on_macos do
@@ -17,11 +19,6 @@ class Ocm < Formula
 
   on_linux do
     depends_on arch: :x86_64
-
-    on_intel do
-      url "https://github.com/openclaw/ocm/releases/download/v0.2.41/ocm-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "e57dc642d70310f8bf19096c0fc41aab0325c8fab24b9ed0c6367c60a02b6198"
-    end
   end
 
   skip_clean "bin/ocm"

--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ Changes to the OCM formula or its updater run installed-Homebrew tests on macOS 
 macOS x86_64, and Linux x86_64, using the checked-out formula rather than the public tap.
 
 Pull requests and updates to `main` run the updater and reconciler tests and validate every formula's
-Ruby syntax.
+Ruby syntax. They also load the checked-out tap on every Homebrew OS/architecture combination,
+including unsupported installation targets. Formulae must always define a URL; use an architecture
+requirement to reject unsupported installs rather than leaving platform metadata empty.
 
 Fleet release workflows use the optional `assets` JSON contract: exactly one `name` and `sha256`
 for each Darwin/Linux amd64/arm64 target. The updater renders those names and hashes verbatim,

--- a/tests/test_ocm_platforms.rb
+++ b/tests/test_ocm_platforms.rb
@@ -1,0 +1,36 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Run with `brew ruby tests/test_ocm_platforms.rb`.
+require "formula"
+
+path = Pathname.new(__dir__).parent/"Formula/ocm.rb"
+targets = {
+  [:macos, :arm]   => "aarch64-apple-darwin",
+  [:macos, :intel] => "x86_64-apple-darwin",
+  [:linux, :intel] => "x86_64-unknown-linux-gnu",
+  [:linux, :arm]   => "x86_64-unknown-linux-gnu",
+}
+
+targets.each do |(os, arch), target|
+  Homebrew::SimulateSystem.with(os:, arch:) do
+    klass = Formulary.load_formula("ocm", path, path.read, "OcmPlatform#{os}#{arch}",
+                                   flags: [], ignore_errors: false)
+    formula = klass.new("ocm", path, :stable, tap: Tap.fetch("openclaw/tap"))
+    url = formula.stable.url
+    raise "Wrong archive for #{os}/#{arch}: #{url}" unless url.end_with?("/ocm-#{target}.tar.gz")
+
+    requirement = formula.requirements.find { |item| item.is_a?(ArchRequirement) }
+    if os == :linux
+      raise "Linux must require x86_64" if requirement&.arch != :x86_64
+      raise "Architecture requirement must reject unsupported installs" unless requirement.fatal?
+
+      # Requirements inspect the real CPU, independently of metadata simulation.
+      native_supported = Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
+      raise "Wrong native CPU acceptance" if requirement.satisfied? != native_supported
+    elsif requirement
+      raise "macOS must support both architectures"
+    end
+    puts "PASS OCM #{os}/#{arch}: #{target}"
+  end
+end

--- a/tests/test_reconcile_formulae.py
+++ b/tests/test_reconcile_formulae.py
@@ -105,8 +105,13 @@ class ReconcileFormulaeTest(unittest.TestCase):
                 pair.group("sha"), hashlib.sha256(url.encode()).hexdigest(),
             )
 
+        download_order = [
+            pair.group("url").replace(f"/{info.current_tag}/", f"/{newer}/")
+            for pair in reconcile_formulae.update_formula.iter_url_sha_pairs(original)
+        ]
+        self.assertCountEqual(download_order, urls)
         for dry_run in (False, True):
-            for failed_download in (False, True):
+            for failed_download in (None, *urls):
                 with self.subTest(dry_run=dry_run, failed_download=failed_download):
                     directory, root = self.make_tap()
                     self.addCleanup(directory.cleanup)
@@ -122,7 +127,7 @@ class ReconcileFormulaeTest(unittest.TestCase):
                             return io.BytesIO(b'{"tag_name":"v1.2.3"}')
                         self.assertIn(url, urls)
                         downloads.append(url)
-                        if failed_download and url == urls[-1]:
+                        if url == failed_download:
                             raise reconcile_formulae.urllib.error.URLError("fixture download failed")
                         return io.BytesIO(url.encode())
 
@@ -143,7 +148,11 @@ class ReconcileFormulaeTest(unittest.TestCase):
                         contextlib.redirect_stdout(output),
                     ):
                         summary = reconcile_formulae.reconcile(root, None, dry_run)
-                    self.assertCountEqual(downloads, urls)
+                    expected_downloads = (
+                        download_order[:download_order.index(failed_download) + 1]
+                        if failed_download else download_order
+                    )
+                    self.assertEqual(downloads, expected_downloads)
                     self.assertEqual(summary, reconcile_formulae.Summary(
                         scanned=2, current=1, drift=1,
                         updated=0 if failed_download else 1,


### PR DESCRIPTION
Fixes #43.

A fresh `brew tap openclaw/tap` evaluates every formula on every platform, including Linux ARM64, even on macOS. OCM's Intel-only Linux URL made that evaluation fail and blocked installation of every package in the tap. Define the Linux archive as the default and retain the macOS overrides and fatal Linux x86_64 requirement. Thanks @jandubois for the report and diagnosis.

The updater now recognizes the standard `url` / `version` / `sha256` layout, so subsequent release updates continue to refresh all three archives. The reconciliation regression checks successful updates and failure of each archive download in both normal and dry-run modes. CI loads the checked-out tap across all Homebrew platforms and checks OCM's archive selection and architecture requirement.

Validation: 73 Python tests pass; all formulae pass Ruby syntax and Homebrew style. The new Homebrew regression fails on the original formula with “formula requires at least a URL” and passes on all four OS/architecture combinations after the repair. The fatal Linux x86_64 requirement rejects the native ARM CPU. Running the real updater against all three published OCM 0.2.41 archives verifies their checksums and leaves the current formula byte-for-byte unchanged.

The changelog is prepared in a separate final notes PR to land after this repair.

## Inspectable runtime proof

Verified on macOS ARM64, Homebrew 6.0.22, at head `b0d89bc73c8fa19e4bc1ae1ec04fd2b31a8603aa`.

### Fresh tap before the repair (original main)

```text
==> Tapping oss-triage/ocm-platform-20260908
Cloning into '$BREW_TAPS/oss-triage/homebrew-ocm-platform-20260908'...
Error: Invalid formula (arm64_linux): $BREW_TAPS/oss-triage/homebrew-ocm-platform-20260908/Formula/ocm.rb
oss-triage/ocm-platform-20260908/ocm: formula requires at least a URL
Error: Cannot tap oss-triage/ocm-platform-20260908: invalid syntax in tap!
```

### Fresh tap after the repair (exact PR head)

```text
==> Tapping oss-triage/ocm-platform-20260908
Cloning into '$BREW_TAPS/oss-triage/homebrew-ocm-platform-20260908'...
Tapped 1 cask and 18 formulae (51 files, 745.2KB).
```

### Homebrew platform regression output

```text
PASS OCM macos/arm: aarch64-apple-darwin
PASS OCM macos/intel: x86_64-apple-darwin
PASS OCM linux/intel: x86_64-unknown-linux-gnu
PASS OCM linux/arm: x86_64-unknown-linux-gnu
```

### Native ARM installation requirement evaluation

```text
native_cpu=arm bits=64
required_arch=x86_64 fatal=true satisfied=false
```

### Real updater: all three published OCM archives

```text
no explicit head; leaving it unchanged
linux_amd64: e57dc642d70310f8bf19096c0fc41aab0325c8fab24b9ed0c6367c60a02b6198  https://github.com/openclaw/ocm/releases/download/v0.2.41/ocm-x86_64-unknown-linux-gnu.tar.gz
darwin_arm64: 99640a65ecc4d8175c76c4336b3b9b3a4c8f9877f40a4b6d9c4ce4c66330b83c  https://github.com/openclaw/ocm/releases/download/v0.2.41/ocm-aarch64-apple-darwin.tar.gz
darwin_amd64: 34b3ec80742df8fdf18290611e3ec30daba1291f0ba1c7b0ef829672036b622e  https://github.com/openclaw/ocm/releases/download/v0.2.41/ocm-x86_64-apple-darwin.tar.gz
updated Formula/ocm.rb to 0.2.41
PASS: all three published archive checksums verified; current formula byte-for-byte unchanged
```

`brew readall --os=all --arch=all oss-triage/ocm-platform-20260908` exited 0. The test tap was cloned from the local checkout; its HEAD matched the PR head above.

Land-ready at `b0d89bc73c8fa19e4bc1ae1ec04fd2b31a8603aa`.

- [CI](https://github.com/openclaw/homebrew-tap/actions/runs/34175327705): success, including all 73 Python tests, formula syntax/style, fresh tap installation, all-platform `brew readall`, and the OCM platform regression.
- [OCM installed-package proof](https://github.com/openclaw/homebrew-tap/actions/runs/34175327704): success on macOS ARM64, macOS Intel, and Linux x86_64. These jobs install the checked-out formula, run the actual executable and `brew test`, compare installed bytes with the published archive, and verify macOS signatures/notarization.
- [CodeQL](https://github.com/openclaw/homebrew-tap/actions/runs/34175326922): success.
- Local and committed-branch autoreview: scoped-clean through P2.

Before/after live reproduction: a fresh temporary tap from the original main fails with `Invalid formula (arm64_linux)` and `formula requires at least a URL`. A fresh tap from this exact PR head successfully loads 18 formulae and one cask; `brew readall --os=all --arch=all` passes. The Linux x86_64 requirement remains fatal and evaluates as unsatisfied on the native ARM CPU.

The real updater also downloaded all three public OCM 0.2.41 archives, matched their SHA-256 values, and left the already-current formula byte-for-byte unchanged. Regression coverage proves a failure at any archive leaves the original formula intact in both update and dry-run modes.

Squash this PR first, then #45 for the consolidated Unreleased notes. Fixes #43. Thanks @jandubois for the report and diagnosis.
