### PR TITLE
docs: refresh tap maintenance notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,18 @@
 
 ## Unreleased
 
-**Highlights:** Install OCM and Peekaboo from the tap, keep Goplaces quarantine protection, and recover release updates without publishing partial formulae.
+**Highlights:** Restore normal tap installation for every package, install OCM and Peekaboo, and recover release updates without publishing partial formulae.
 
-- Update OCM to v0.2.40 for macOS ARM64/Intel and Linux x86_64, preserving signed release binaries and testing installed packages on all three platforms. Use `brew upgrade openclaw/tap/ocm`; self-update now refuses to replace Homebrew-managed binaries.
-- Add the Peekaboo 4.3.1 universal macOS formula and list it in the package guide.
+- Fix `brew tap openclaw/tap` rejecting the entire tap when validating OCM on Linux ARM64; retain the Linux x86_64 installation requirement and validate all Homebrew platforms in CI; thanks @jandubois.
+- Update OCM to v0.2.41 for macOS ARM64/Intel and Linux x86_64, preserving signed release binaries and testing installed packages on all three platforms. Use `brew upgrade openclaw/tap/ocm`; self-update now refuses to replace Homebrew-managed binaries.
+- Add the Peekaboo universal macOS formula, update it to 4.3.2, and match its v4 help header in the installed smoke test.
 - Remove the deprecated Goplaces postflight hook, preserving quarantine on signed, notarized binaries and eliminating Homebrew's warning; thanks @karbo-hub.
 - Validate every checksum-download redirect before following it, rejecting HTTPS downgrades, credentials, and fragments while preserving the existing host contract; thanks @SebTardif.
 - Automatically reconcile formulae with their latest stable source releases every three hours without downgrading or selecting drafts and prereleases.
 - Reject unrecognized release assets before partial updates while preserving smaller legacy target inventories and resources; thanks @SebTardif.
 - Keep Linux source-archive URLs and checksums in sync during multi-target updates; thanks @SebTardif.
 - Leave no zero-checksum formula behind when a new formula download fails; thanks @SebTardif.
+- Keep release URLs and checksums synchronized when a formula places its explicit version between them, and preserve the formula if any OCM archive download fails.
 - Keep reconciling later formulae when an artifact template is invalid; thanks @SebTardif.
 - Fail stalled formula and cask downloads with a 30-second socket timeout; thanks @SebTardif.
 - Stop stalled source-tag Git fetches and lookups after 60 seconds; thanks @SebTardif.


### PR DESCRIPTION
Refresh the consolidated Unreleased notes with the tap installation repair, continued three-platform OCM updates, and the current OCM 0.2.41 and Peekaboo 4.3.2 packages. Credit @jandubois for identifying the tap-wide installation blocker.

Land after #44, the OCM platform-validation repair. This branch changes only CHANGELOG.md and is independently based on main. All 18 formulae, the Goplaces cask, and both pinned GitHub Actions were checked against current stable releases; no dependency bumps were needed. This tap distributes through Git and has no version tags or GitHub release channel to publish.

The prerequisite is prepared and verified, and remains intentionally unmerged pending maintainer authorization. See [its terminal output and green three-platform install proof](https://github.com/openclaw/homebrew-tap/pull/44).

Verified head `1fc52a3a98891213def954d336c4644314341ef9`.

- [CI](https://github.com/openclaw/homebrew-tap/actions/runs/34175328923): success.
- [CodeQL](https://github.com/openclaw/homebrew-tap/actions/runs/34175327369): success.
- Local and committed-branch autoreview: scoped-clean through P2.
- The branch changes only the consolidated Unreleased notes. All 18 formulae, the Goplaces cask, and both pinned Actions match their current stable upstream releases.

Land after #44. Its live tap, all-platform metadata, and release-archive checksum proof substantiate the new fix notes. No versioned release is proposed for this Git-distributed tap.

## Rendered changelog preview

The following is copied verbatim from the candidate CHANGELOG.md and rendered here as Markdown.

# Changelog

## Unreleased

**Highlights:** Restore normal tap installation for every package, install OCM and Peekaboo, and recover release updates without publishing partial formulae.

- Fix `brew tap openclaw/tap` rejecting the entire tap when validating OCM on Linux ARM64; retain the Linux x86_64 installation requirement and validate all Homebrew platforms in CI; thanks @jandubois.
- Update OCM to v0.2.41 for macOS ARM64/Intel and Linux x86_64, preserving signed release binaries and testing installed packages on all three platforms. Use `brew upgrade openclaw/tap/ocm`; self-update now refuses to replace Homebrew-managed binaries.
- Add the Peekaboo universal macOS formula, update it to 4.3.2, and match its v4 help header in the installed smoke test.
- Remove the deprecated Goplaces postflight hook, preserving quarantine on signed, notarized binaries and eliminating Homebrew's warning; thanks @karbo-hub.
- Validate every checksum-download redirect before following it, rejecting HTTPS downgrades, credentials, and fragments while preserving the existing host contract; thanks @SebTardif.
- Automatically reconcile formulae with their latest stable source releases every three hours without downgrading or selecting drafts and prereleases.
- Reject unrecognized release assets before partial updates while preserving smaller legacy target inventories and resources; thanks @SebTardif.
- Keep Linux source-archive URLs and checksums in sync during multi-target updates; thanks @SebTardif.
- Leave no zero-checksum formula behind when a new formula download fails; thanks @SebTardif.
- Keep release URLs and checksums synchronized when a formula places its explicit version between them, and preserve the formula if any OCM archive download fails.
- Keep reconciling later formulae when an artifact template is invalid; thanks @SebTardif.
- Fail stalled formula and cask downloads with a 30-second socket timeout; thanks @SebTardif.
- Stop stalled source-tag Git fetches and lookups after 60 seconds; thanks @SebTardif.
- Update the `slacrawl` formula to 0.8.7 with verified macOS and Linux archives for Intel and ARM.
- Update the `goplaces` cask to 0.4.9 with the `--radius` alias and signed, notarized macOS binaries.
- Preserve formula-owned install instructions and caveats while accepting exact four-platform release asset inventories and verified source-tag provenance.
- Align Crabbox tap updates with published releases and downloaded checksums, with reconciliation as a recovery path.
- Validate release-dispatch inputs and require protected-default-branch execution for formula automation.
- Correct Gitcrawl configuration paths and direct GitHub shim users to Octopool.
- Provide Homebrew formulae for axorc, clawscan, clawdex, crabbox, crabfleet, crawlbar, discrawl, gitcrawl, gogcli, graincrawl, notcrawl, octopool, slacrawl, telecrawl, wacli, and wacrawl, plus the Goplaces cask.
