### PR TITLE
feat: add FaceTime formula release profile

### DIFF
--- a/.github/formula-profiles/openclaw-facetime.rb
+++ b/.github/formula-profiles/openclaw-facetime.rb
@@ -1,0 +1,51 @@
+class OpenclawFacetime < Formula
+  desc "Native FaceTime audio and call-control helpers for OpenClaw"
+  homepage "https://github.com/openclaw/openclaw-facetime"
+  url "https://github.com/openclaw/openclaw-facetime/releases/download/v0.1.0/openclaw-facetime-macos-arm64.zip"
+  sha256 "RELEASE_SHA256"
+  license "MIT"
+
+  depends_on arch: :arm64
+  depends_on macos: :sonoma
+  depends_on "sox"
+
+  skip_clean "libexec/facetime-audio-capture", "libexec/FaceTimeHelper.dylib"
+
+  def install
+    odie "openclaw-facetime requires macOS 14.4 or later" if MacOS.version < "14.4"
+    libexec.install "facetime-audio-capture"
+    libexec.install "FaceTimeHelper.dylib"
+    libexec.install "FaceTimeHelper.build-id"
+    libexec.install "VERSION"
+    libexec.install "native-protocol.env"
+    libexec.install "LICENSE"
+    libexec.install "THIRD_PARTY_NOTICES.md"
+  end
+
+  def caveats
+    <<~EOS
+      This formula installs native helpers consumed by the OpenClaw FaceTime
+      plugin and SoX for the host-owned playback process. It does not install or
+      enable the plugin itself.
+
+      Install and configure the plugin separately:
+        https://docs.openclaw.ai/plugins/facetime
+
+      Call control requires SIP debugging restrictions disabled and Developer
+      Tools access enabled. The separately built GPL-derived audio driver is
+      intentionally not included in this formula.
+    EOS
+  end
+
+  test do
+    assert_predicate libexec/"facetime-audio-capture", :executable?
+    assert_path_exists libexec/"FaceTimeHelper.dylib"
+    assert_match(/\A[0-9a-f]{64}\n?\z/, (libexec/"FaceTimeHelper.build-id").read)
+    assert_match version.to_s, (libexec/"VERSION").read
+    assert_equal "NATIVE_PROTOCOL_VERSION=1\n", (libexec/"native-protocol.env").read
+    system "/usr/bin/codesign", "--verify", "--strict", "--check-notarization",
+           "-R=notarized", libexec/"facetime-audio-capture"
+    system "/usr/bin/codesign", "--verify", "--strict", "--check-notarization",
+           "-R=notarized", libexec/"FaceTimeHelper.dylib"
+  end
+end

--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -22,6 +22,7 @@ import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
+from typing import NamedTuple
 
 
 USER_AGENT = "steipete-homebrew-tap-updater"
@@ -39,6 +40,23 @@ CANONICAL_TARGETS = frozenset(("darwin_universal", *RELEASE_TARGETS))
 TEMPLATE_FIELDS = frozenset(("formula", "version", "tag", "target"))
 
 
+class FormulaProfile(NamedTuple):
+    formula: str
+    repository: str
+    artifact: str
+    template: pathlib.Path
+
+
+FORMULA_PROFILES = {
+    "openclaw-facetime": FormulaProfile(
+        formula="openclaw-facetime",
+        repository="openclaw/openclaw-facetime",
+        artifact="openclaw-facetime-macos-arm64.zip",
+        template=pathlib.Path(".github/formula-profiles/openclaw-facetime.rb"),
+    ),
+}
+
+
 def is_crabbox_formula(path: pathlib.Path) -> bool:
     crabbox = pathlib.Path("Formula/crabbox.rb")
     return path.resolve() == crabbox.resolve() or (
@@ -50,6 +68,22 @@ def validate_tap_token(value: str, description: str) -> str:
     if not TAP_TOKEN_PATTERN.fullmatch(value):
         raise SystemExit(f"invalid {description} {value!r}; expected a Homebrew-safe token")
     return value
+
+
+def resolve_formula_profile(value: str, formula: str, repository: str) -> FormulaProfile:
+    validate_tap_token(value, "formula profile")
+    profile = FORMULA_PROFILES.get(value)
+    if profile is None:
+        raise SystemExit(f"unknown formula profile {value!r}")
+    if formula != profile.formula:
+        raise SystemExit(
+            f"formula profile {value!r} requires formula {profile.formula!r}, got {formula!r}"
+        )
+    if repository != profile.repository:
+        raise SystemExit(
+            f"formula profile {value!r} requires repository {profile.repository!r}, got {repository!r}"
+        )
+    return profile
 
 
 def validate_repository(value: str) -> str:
@@ -1078,6 +1112,10 @@ def update_repository_metadata(text: str, repository: str) -> str:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--formula", required=True, help="Formula name, e.g. wacli")
+    parser.add_argument(
+        "--formula-profile",
+        help="Allowlisted tap-owned profile used to create or update a specialized formula",
+    )
     parser.add_argument("--tag", required=True, help="Release tag, e.g. v0.7.0")
     parser.add_argument("--repository", required=True, help="Source repository, e.g. steipete/wacli")
     parser.add_argument("--assets-json", help="Exact four-platform asset name/SHA-256 JSON")
@@ -1140,6 +1178,11 @@ def main(argv: list[str] | None = None) -> int:
     args.formula = validate_tap_token(args.formula, "formula")
     args.repository = validate_repository(args.repository)
     args.tag = validate_release_tag(args.tag)
+    formula_profile = (
+        resolve_formula_profile(args.formula_profile, args.formula, args.repository)
+        if args.formula_profile
+        else None
+    )
     if args.cask:
         args.cask = validate_tap_token(args.cask, "cask")
     if args.macos_artifact:
@@ -1165,6 +1208,28 @@ def main(argv: list[str] | None = None) -> int:
         args.source_tag_object,
         args.request_id,
     )
+    if formula_profile is not None:
+        incompatible = [
+            option
+            for option, value in (
+                ("assets", explicit_assets),
+                ("description", args.description),
+                ("macos_artifact", args.macos_artifact),
+                ("linux_url", args.linux_url),
+                ("artifact_template", args.artifact_template),
+                ("artifact_url", args.artifact_url),
+                ("target_aliases", args.target_aliases),
+                ("verified_hashes", verified_hashes),
+                ("cask", args.cask),
+                ("cask_artifact", args.cask_artifact),
+            )
+            if value
+        ]
+        if incompatible:
+            raise SystemExit(
+                "formula-profile mode does not support other artifact contracts: "
+                + ", ".join(incompatible)
+            )
     if verified_hashes is not None:
         if not args.verify_source_tag_only:
             paths = [tap_path("Formula", args.formula)]
@@ -1228,6 +1293,23 @@ def main(argv: list[str] | None = None) -> int:
                 artifact_target,
             )
             validate_artifact_token(artifact, f"artifact for {target}")
+
+    if formula_profile is not None:
+        path = tap_path("Formula", args.formula)
+        source = path if path.exists() else formula_profile.template
+        if not source.is_file():
+            raise SystemExit(f"formula profile template {formula_profile.template} does not exist")
+        url = (
+            f"https://github.com/{formula_profile.repository}/releases/download/"
+            f"{args.tag}/{formula_profile.artifact}"
+        )
+        digest = sha256(url)
+        text = update_top_level_url_and_sha(source.read_text(), url, digest, version)
+        path.write_text(text)
+        verb = "created" if source == formula_profile.template else "updated"
+        print(f"profile: {digest}  {url}")
+        print(f"{verb} {path} to {version}")
+        return 0
 
     if verified_hashes is not None:
         assert args.source_tag_object is not None

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
 
       - name: Validate formula syntax
         run: |
+          for profile in .github/formula-profiles/*.rb; do
+            ruby -c "$profile"
+          done
           for formula in Formula/*.rb; do
             ruby -c "$formula"
           done

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -8,6 +8,10 @@ on:
         description: "Formula name (e.g., gitcrawl)"
         required: true
         type: string
+      formula_profile:
+        description: "Optional tap-owned formula profile (openclaw-facetime)"
+        required: false
+        type: string
       tag:
         description: "Release tag to update formula for"
         required: true
@@ -118,6 +122,7 @@ jobs:
           DARWIN_ARM64_SHA256: ${{ inputs.darwin_arm64_sha256 }}
           DESCRIPTION: ${{ inputs.description }}
           FORMULA: ${{ inputs.formula }}
+          FORMULA_PROFILE: ${{ inputs.formula_profile }}
           LINUX_AMD64_SHA256: ${{ inputs.linux_amd64_sha256 }}
           LINUX_ARM64_SHA256: ${{ inputs.linux_arm64_sha256 }}
           LINUX_URL: ${{ inputs.linux_url }}
@@ -134,6 +139,10 @@ jobs:
             --tag "$TAG"
             --repository "$REPOSITORY"
           )
+
+          if [ -n "$FORMULA_PROFILE" ]; then
+            args+=(--formula-profile "$FORMULA_PROFILE")
+          fi
 
           if [ -n "$ASSETS_JSON" ]; then
             args+=(--assets-json "$ASSETS_JSON")
@@ -204,6 +213,9 @@ jobs:
       - name: Validate update
         run: |
           python3 -m unittest discover -s tests -v
+          for profile in .github/formula-profiles/*.rb; do
+            ruby -c "$profile"
+          done
           for formula in Formula/*.rb; do
             ruby -c "$formula"
           done
@@ -334,6 +346,9 @@ jobs:
 
             git pull --rebase origin "$DEFAULT_BRANCH"
             python3 -m unittest discover -s tests -v
+            for profile in .github/formula-profiles/*.rb; do
+              ruby -c "$profile"
+            done
             for formula in Formula/*.rb; do
               ruby -c "$formula"
             done

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / ".github" / "scripts" / "update_formula.py"
+FACETIME_PROFILE = ROOT / ".github" / "formula-profiles" / "openclaw-facetime.rb"
 SPEC = importlib.util.spec_from_file_location("update_formula", SCRIPT)
 assert SPEC and SPEC.loader
 update_formula = importlib.util.module_from_spec(SPEC)
@@ -76,6 +77,119 @@ def crabbox_arguments(mode: str) -> list[str]:
 
 
 class UpdateFormulaTest(unittest.TestCase):
+    def test_formula_profile_allowlist_binds_name_repository_artifact_and_template(self) -> None:
+        profile = update_formula.resolve_formula_profile(
+            "openclaw-facetime",
+            "openclaw-facetime",
+            "openclaw/openclaw-facetime",
+        )
+        self.assertEqual(profile.formula, "openclaw-facetime")
+        self.assertEqual(profile.repository, "openclaw/openclaw-facetime")
+        self.assertEqual(profile.artifact, "openclaw-facetime-macos-arm64.zip")
+        self.assertEqual(profile.template, pathlib.Path(".github/formula-profiles/openclaw-facetime.rb"))
+
+    def test_formula_profile_rejects_mismatches_and_untrusted_names_before_side_effects(self) -> None:
+        cases = (
+            ("openclaw-facetime", "other", "openclaw/openclaw-facetime", "requires formula"),
+            ("openclaw-facetime", "openclaw-facetime", "openclaw/other", "requires repository"),
+            ("unknown", "openclaw-facetime", "openclaw/openclaw-facetime", "unknown formula profile"),
+            ("../../openclaw-facetime", "openclaw-facetime", "openclaw/openclaw-facetime", "invalid formula profile"),
+        )
+        for profile, formula, repository, message in cases:
+            with self.subTest(profile=profile, formula=formula, repository=repository):
+                with (
+                    mock.patch.object(update_formula, "sha256") as download,
+                    mock.patch.object(pathlib.Path, "write_text") as write,
+                    self.assertRaisesRegex(SystemExit, message),
+                ):
+                    update_formula.main([
+                        "--formula", formula,
+                        "--formula-profile", profile,
+                        "--tag", "v1.2.3",
+                        "--repository", repository,
+                    ])
+                download.assert_not_called()
+                write.assert_not_called()
+
+    def test_formula_profile_rejects_artifact_overrides_before_side_effects(self) -> None:
+        with (
+            mock.patch.object(update_formula, "sha256") as download,
+            mock.patch.object(pathlib.Path, "write_text") as write,
+            self.assertRaisesRegex(SystemExit, "other artifact contracts: macos_artifact"),
+        ):
+            update_formula.main([
+                "--formula", "openclaw-facetime",
+                "--formula-profile", "openclaw-facetime",
+                "--tag", "v1.2.3",
+                "--repository", "openclaw/openclaw-facetime",
+                "--macos-artifact", "other.zip",
+            ])
+        download.assert_not_called()
+        write.assert_not_called()
+
+    def test_facetime_profile_seeds_then_updates_one_verified_artifact(self) -> None:
+        arguments = [
+            "--formula", "openclaw-facetime",
+            "--formula-profile", "openclaw-facetime",
+            "--tag", "v1.2.3",
+            "--repository", "openclaw/openclaw-facetime",
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "Formula").mkdir()
+            profile = root / ".github" / "formula-profiles" / "openclaw-facetime.rb"
+            profile.parent.mkdir(parents=True)
+            profile.write_bytes(FACETIME_PROFILE.read_bytes())
+            formula = root / "Formula" / "openclaw-facetime.rb"
+            previous_directory = pathlib.Path.cwd()
+            os.chdir(root)
+            try:
+                with mock.patch.object(update_formula, "sha256", return_value="e" * 64) as download:
+                    self.assertEqual(update_formula.main(arguments), 0)
+                first = formula.read_text()
+                first_url = (
+                    "https://github.com/openclaw/openclaw-facetime/releases/download/"
+                    "v1.2.3/openclaw-facetime-macos-arm64.zip"
+                )
+                download.assert_called_once_with(first_url)
+                self.assertIn(f'  url "{first_url}"', first)
+                self.assertIn(f'  sha256 "{"e" * 64}"', first)
+
+                with mock.patch.object(update_formula, "sha256", return_value="f" * 64) as download:
+                    self.assertEqual(update_formula.main([
+                        *arguments[:5], "v1.2.4", *arguments[6:]
+                    ]), 0)
+                second = formula.read_text()
+            finally:
+                os.chdir(previous_directory)
+
+            second_url = (
+                "https://github.com/openclaw/openclaw-facetime/releases/download/"
+                "v1.2.4/openclaw-facetime-macos-arm64.zip"
+            )
+            download.assert_called_once_with(second_url)
+            expected = first.replace(first_url, second_url).replace("e" * 64, "f" * 64)
+            self.assertEqual(second, expected)
+
+    def test_facetime_profile_owns_seven_runtime_files_and_sox_dependency(self) -> None:
+        text = FACETIME_PROFILE.read_text()
+        self.assertEqual(
+            re.findall(r'^\s+libexec\.install "([^"]+)"$', text, re.MULTILINE),
+            [
+                "facetime-audio-capture",
+                "FaceTimeHelper.dylib",
+                "FaceTimeHelper.build-id",
+                "VERSION",
+                "native-protocol.env",
+                "LICENSE",
+                "THIRD_PARTY_NOTICES.md",
+            ],
+        )
+        self.assertIn('  depends_on "sox"', text)
+        self.assertIn("  depends_on arch: :arm64", text)
+        self.assertEqual(text.count("  url "), 1)
+        self.assertNotIn('system "swift"', text)
+
     def assert_crabbox_verified_write_rejection(self, root: pathlib.Path, arguments: list[str]) -> None:
         before = {path.relative_to(root): path.read_bytes() for path in root.rglob("*") if path.is_file()}
         previous_directory = pathlib.Path.cwd()

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -61,6 +61,16 @@ class WorkflowSecurityTest(unittest.TestCase):
         self.assertNotIn("GITHUB_TOKEN", text)
         self.assertNotIn("GITHUB_TOKEN", (ROOT / ".github" / "scripts" / "update_formula.py").read_text())
 
+    def test_formula_profile_input_is_forwarded_and_validated_as_data(self) -> None:
+        text = UPDATE_WORKFLOW.read_text()
+        self.assertRegex(text, r"(?m)^      formula_profile:$")
+        self.assertIn("FORMULA_PROFILE: ${{ inputs.formula_profile }}", text)
+        update = named_step_run(text, "Update formula")
+        self.assertIn('args+=(--formula-profile "$FORMULA_PROFILE")', update)
+        validation = named_step_run(text, "Validate update")
+        self.assertIn('ruby -c "$profile"', validation)
+        self.assertIn("brew style Formula/*.rb", validation)
+
     def test_dispatch_is_bound_to_the_exact_protected_default_branch_workflow(self) -> None:
         text = UPDATE_WORKFLOW.read_text()
         self.assertIn("# verified-hashes-v1", text)
@@ -154,6 +164,7 @@ class WorkflowSecurityTest(unittest.TestCase):
                 "DARWIN_ARM64_SHA256": "",
                 "DESCRIPTION": "",
                 "FORMULA": payload,
+                "FORMULA_PROFILE": payload,
                 "LINUX_AMD64_SHA256": "",
                 "LINUX_ARM64_SHA256": "",
                 "LINUX_URL": "",
@@ -174,6 +185,7 @@ class WorkflowSecurityTest(unittest.TestCase):
 
             arguments = capture.read_bytes().split(b"\0")
             self.assertIn(payload.encode(), arguments)
+            self.assertEqual(arguments.count(payload.encode()), 2)
             self.assertFalse(marker.exists())
 
     def test_dispatch_validates_before_push(self) -> None:
@@ -272,7 +284,7 @@ with mock.patch("urllib.request.OpenerDirector.open", side_effect=download), \\
                 environment = dict.fromkeys((
                     "ARTIFACT_TEMPLATE", "ARTIFACT_URL", "ASSETS_JSON", "CASK", "CASK_ARTIFACT",
                     "DARWIN_AMD64_SHA256", "DARWIN_ARM64_SHA256", "DESCRIPTION", "LINUX_AMD64_SHA256",
-                    "LINUX_ARM64_SHA256", "LINUX_URL", "MACOS_ARTIFACT", "REQUEST_ID",
+                    "FORMULA_PROFILE", "LINUX_ARM64_SHA256", "LINUX_URL", "MACOS_ARTIFACT", "REQUEST_ID",
                     "SOURCE_TAG_COMMIT", "SOURCE_TAG_OBJECT", "TARGET_ALIASES",
                 ), "")
                 environment.update({
@@ -324,12 +336,15 @@ with mock.patch("urllib.request.OpenerDirector.open", side_effect=download), \\
                     else:
                         self.assertEqual(completed.returncode, 0, completed.stderr)
                         self.assertEqual(formula.read_text(), expected)
-                        self.assertEqual(calls[:5], ["tests", "ruby", "style", "git add Formula/crabbox.rb", "git diff --cached --quiet"])
+                        self.assertEqual(calls[:6], [
+                            "tests", "ruby", "ruby", "style",
+                            "git add Formula/crabbox.rb", "git diff --cached --quiet",
+                        ])
                         if mode == "noop":
-                            self.assertEqual(len(calls), 5)
+                            self.assertEqual(len(calls), 6)
                             self.assertIn("already up to date", completed.stdout)
                         else:
-                            self.assertEqual(calls[5:], [
+                            self.assertEqual(calls[6:], [
                                 "git commit -m crabbox: update formula for v1.2.3",
                                 "gh auth setup-git", "git push origin HEAD:refs/heads/main",
                             ])


### PR DESCRIPTION
## Summary

- add the allowlisted `openclaw-facetime` formula profile used by the native release workflow
- bind the profile to the exact formula, repository, artifact name, and tap-owned template
- seed the first formula only after hashing the public arm64 release archive, then preserve the body and update URL/SHA on later releases
- reject unknown, unsafe, mismatched, or conflicting profile inputs before downloads or writes
- port the profile path onto the current `formula_text.py` owner after merging current `main`

This is the tap-side prerequisite for publishing `openclaw/openclaw-facetime` through its hardened release workflow.

## Validation

- 84 Python tests passed under Homebrew Python 3.14
- Python byte compilation passed
- workflow YAML and Ruby syntax checks passed
- `brew style` passed for all 20 rendered formula/cask files
- `git diff --check` passed
- profile is byte-identical to `packaging/homebrew/openclaw-facetime.rb` on native `main`

## Real public-release proof

- Public release: https://github.com/openclaw/openclaw-facetime/releases/tag/v0.1.0
- Anonymous archive download succeeded without GitHub credentials
- Archive SHA-256: `0fe80486f2609ba02e7ce4f0429bd9240b00640b4b1705b4656f54cd5530516e`
- The profile updater downloaded that public archive and rendered `Formula/openclaw-facetime.rb` with the same digest
- Rendered formula passed Ruby syntax and Homebrew style checks
- Native release workflow passed Developer ID signing, Apple notarization, independent asset redownload, and strict notarization verification for both binaries before intentionally stopping at the missing tap-profile gate

The clean Homebrew install and installed-binary verification will run immediately after this profile merges and the updater creates the formula.
