### PR TITLE
chore(deps): update OCM to 0.2.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Highlights:** Restore normal tap installation for every package, install OCM and Peekaboo, and recover release updates without publishing partial formulae.
 
 - Fix `brew tap openclaw/tap` rejecting the entire tap when validating OCM on Linux ARM64; retain the Linux x86_64 installation requirement and validate all Homebrew platforms in CI; thanks @jandubois.
-- Update OCM to v0.2.41 for macOS ARM64/Intel and Linux x86_64, preserving signed release binaries and testing installed packages on all three platforms. Use `brew upgrade openclaw/tap/ocm`; self-update now refuses to replace Homebrew-managed binaries.
+- Update OCM to v0.2.45 for macOS ARM64/Intel and Linux x86_64, including environment artifact exports, stopped-session recovery, environment-variable UI paths, and safer environment roots. Preserve signed release binaries; use `brew upgrade openclaw/tap/ocm`.
 - Add the Peekaboo universal macOS formula, update it to 4.3.2, and match its v4 help header in the installed smoke test.
 - Remove the deprecated Goplaces postflight hook, preserving quarantine on signed, notarized binaries and eliminating Homebrew's warning; thanks @karbo-hub.
 - Validate every checksum-download redirect before following it, rejecting HTTPS downgrades, credentials, and fragments while preserving the existing host contract; thanks @SebTardif.

--- a/Formula/ocm.rb
+++ b/Formula/ocm.rb
@@ -1,19 +1,19 @@
 class Ocm < Formula
   desc "Manage isolated OpenClaw environments, runtimes, and services"
   homepage "https://github.com/openclaw/ocm"
-  url "https://github.com/openclaw/ocm/releases/download/v0.2.44/ocm-x86_64-unknown-linux-gnu.tar.gz"
-  version "0.2.44"
-  sha256 "73c9ae077986bbb76e79cf1ded9ed285547124c045c91d08e4330552b7e805b0"
+  url "https://github.com/openclaw/ocm/releases/download/v0.2.45/ocm-x86_64-unknown-linux-gnu.tar.gz"
+  version "0.2.45"
+  sha256 "5ed55e0c4b54a561e09b8204b1ae97a6c743b13f35e383611e84729561de924e"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/openclaw/ocm/releases/download/v0.2.44/ocm-aarch64-apple-darwin.tar.gz"
-      sha256 "5af02cca61951f3bad795e435871a337645cf95c247ac51eef4899fe066e2011"
+      url "https://github.com/openclaw/ocm/releases/download/v0.2.45/ocm-aarch64-apple-darwin.tar.gz"
+      sha256 "bee47c66dc0f4710f0c9106fc2bfc3ed025c758fa580c74b86be674068dc188b"
     end
     on_intel do
-      url "https://github.com/openclaw/ocm/releases/download/v0.2.44/ocm-x86_64-apple-darwin.tar.gz"
-      sha256 "86c8056dd2ca7a055033a88a4e7ec7e38e5e14da6b8205567bdf5b6f89d9c86b"
+      url "https://github.com/openclaw/ocm/releases/download/v0.2.45/ocm-x86_64-apple-darwin.tar.gz"
+      sha256 "05d6087c93c6c10877ccd0f6fcf756f2cd3b982c2254a994a3bff1c492c7251b"
     end
   end
 


### PR DESCRIPTION
The tap still points at OCM 0.2.44 after the upstream 0.2.45 release. Update the three supported archive URLs and their downloaded SHA-256 values, and refresh the existing Unreleased OCM entry. The formula keeps its install recipe, signature preservation, and Linux x86_64 requirement.

OCM 0.2.45 adds environment artifact exports and fixes stopped development-session recovery, UI paths containing environment variables, and environment-root handling.

Validation:
- The real reconciler scanned all 18 formulae and found only OCM stale. It downloaded all three 0.2.45 archives; computed hashes match GitHub's published asset digests.
- All 73 Python tests passed. Homebrew style passed for all 18 formulae; OCM metadata loaded successfully for macOS ARM/Intel and Linux ARM/Intel, with unsupported Linux ARM installation still rejected.
- The published macOS ARM64 executable passed strict Developer ID and notarization checks, reported version 0.2.45, and ran its top-level and environment help commands.
- Independent autoreview and exact-head CI installation proof are recorded in the follow-up proof comment.

This is a Homebrew dependency update. The tap is distributed through Git; no tap tag or release is needed.
