### PR TITLE
refactor: unify formula target rendering

### DIFF
--- a/.github/scripts/reconcile_formulae.py
+++ b/.github/scripts/reconcile_formulae.py
@@ -35,7 +35,6 @@ HOMEPAGE_PATTERN = re.compile(
     re.MULTILINE,
 )
 VERSION_PATTERN = re.compile(r'^\s*version\s+"([^"]+)"\s*$', re.MULTILINE)
-FORMULA_PATTERN = re.compile(r"[a-z0-9][a-z0-9+@._-]*")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -139,7 +138,6 @@ def marker_for_target(asset: str, target: str) -> str:
 def infer_update_options(
     text: str,
     repository: str,
-    formula: str,
     current_tag: str,
     version: str,
 ) -> tuple[str, ...]:
@@ -223,7 +221,6 @@ def parse_formula(path: pathlib.Path) -> FormulaInfo:
         update_options = infer_update_options(
             text,
             repository,
-            path.stem,
             current_tag,
             version_text,
         )
@@ -317,7 +314,7 @@ def run_update(root: pathlib.Path, info: FormulaInfo, latest_tag: str, dry_run: 
 
 def formula_paths(root: pathlib.Path, selected: str | None) -> list[pathlib.Path]:
     if selected:
-        if not FORMULA_PATTERN.fullmatch(selected):
+        if not update_formula.TAP_TOKEN_PATTERN.fullmatch(selected):
             raise ValueError(f"invalid formula {selected!r}")
         path = root / "Formula" / f"{selected}.rb"
         if not path.is_file():

--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -447,27 +447,8 @@ def iter_primary_url_sha_pairs(text: str) -> list[re.Match[str]]:
 
 
 def stanza_body(text: str, stanza: str) -> str | None:
-    match = re.search(
-        rf'^\s*{stanza}\s+do\s*$\n(?P<body>.*?)(?=^\s*(?:on_macos\s+do|on_linux\s+do|resource\s+|head |def |test do))',
-        text,
-        flags=re.MULTILINE | re.DOTALL,
-    )
-    if not match:
-        return None
-    return match.group("body")
-
-
-def require_single_sha_in_stanza(text: str, stanza: str) -> None:
-    body = stanza_body(text, stanza)
-    if body is None:
-        return
-
-    checksums = re.findall(r'^\s*sha256\s+"[^"]+"', body, flags=re.MULTILINE)
-    if len(checksums) != 1:
-        raise SystemExit(
-            f"expected exactly one sha256 in {stanza} stanza, found {len(checksums)}; "
-            "formulae with multiple architecture-specific checksums need manual updates"
-        )
+    match = stanza_match(text, stanza)
+    return match.group("body") if match else None
 
 
 def stanza_url_shape_count(text: str, stanza: str, version: str) -> int:
@@ -659,21 +640,16 @@ def predicate_architecture(line: str) -> str | None:
     return None
 
 
-def update_verified_stanza(
+def update_target_stanza(
     text: str,
     stanza: str,
-    repository: str,
-    tag: str,
-    formula: str,
-    version: str,
-    template: str,
-    target_aliases: dict[str, str],
-    hashes: dict[str, str],
+    assets: dict[str, tuple[str, str]],
+    mode: str,
 ) -> str:
     matches = list(re.finditer(rf"^  {stanza} do$", text, flags=re.MULTILINE))
     match = stanza_match(text, stanza)
     if len(matches) != 1 or match is None:
-        raise SystemExit(f"verified-hash mode requires exactly one {stanza} stanza")
+        raise SystemExit(f"{mode} requires exactly one {stanza} stanza")
 
     prefix = "darwin" if stanza == "on_macos" else "linux"
     lines = match.group("body").splitlines(keepends=True)
@@ -690,7 +666,7 @@ def update_verified_stanza(
             continue
         if re.fullmatch(r"    else\n?", lines[index]):
             if conditional_architecture is None:
-                raise SystemExit(f"verified-hash mode found an unmatched else in {stanza}")
+                raise SystemExit(f"{mode} found an unmatched else in {stanza}")
             current_architecture = "amd64" if conditional_architecture == "arm64" else "arm64"
             index += 1
             continue
@@ -705,92 +681,25 @@ def update_verified_stanza(
             index += 1
             continue
         if current_architecture is None or index + 1 >= len(lines):
-            raise SystemExit(f"verified-hash mode could not bind a {stanza} URL to an architecture predicate")
+            raise SystemExit(f"{mode} could not bind a {stanza} URL to an architecture predicate")
         sha_match = re.fullmatch(r'(\s+)sha256 "[0-9a-f]+"\n?', lines[index + 1])
         if not sha_match or sha_match.group(1) != url_match.group(1):
-            raise SystemExit(f"verified-hash mode requires adjacent URL/checksum pairs in {stanza}")
+            raise SystemExit(f"{mode} requires adjacent URL/checksum pairs in {stanza}")
 
         target = f"{prefix}_{current_architecture}"
         if target in seen_targets:
-            raise SystemExit(f"verified-hash mode found duplicate {target} URL/checksum pairs")
+            raise SystemExit(f"{mode} found duplicate {target} URL/checksum pairs")
         newline = "\n" if lines[index].endswith("\n") else ""
         indentation = url_match.group(1)
-        url = interpolated_target_url(
-            repository, tag, formula, version, template, target_aliases, target
-        )
+        url, digest = assets[target]
         lines[index] = f'{indentation}url "{url}"{newline}'
-        lines[index + 1] = f'{indentation}sha256 "{hashes[target]}"{newline}'
+        lines[index + 1] = f'{indentation}sha256 "{digest}"{newline}'
         seen_targets.add(target)
         index += 2
 
     expected_targets = {f"{prefix}_arm64", f"{prefix}_amd64"}
     if seen_targets != expected_targets:
-        raise SystemExit(f"verified-hash mode requires exact arm64 and amd64 pairs in {stanza}")
-    body = "".join(lines)
-    return text[: match.start("body")] + body + text[match.end("body") :]
-
-
-def update_explicit_stanza(
-    text: str,
-    stanza: str,
-    repository: str,
-    tag: str,
-    assets: dict[str, dict[str, str]],
-) -> str:
-    matches = list(re.finditer(rf"^  {stanza} do$", text, flags=re.MULTILINE))
-    match = stanza_match(text, stanza)
-    if len(matches) != 1 or match is None:
-        raise SystemExit(f"explicit-assets mode requires exactly one {stanza} stanza")
-
-    prefix = "darwin" if stanza == "on_macos" else "linux"
-    lines = match.group("body").splitlines(keepends=True)
-    current_architecture: str | None = None
-    conditional_architecture: str | None = None
-    seen_targets: set[str] = set()
-    index = 0
-    while index < len(lines):
-        architecture = predicate_architecture(lines[index])
-        if architecture:
-            current_architecture = architecture
-            conditional_architecture = architecture
-            index += 1
-            continue
-        if re.fullmatch(r"    else\n?", lines[index]):
-            if conditional_architecture is None:
-                raise SystemExit(f"explicit-assets mode found an unmatched else in {stanza}")
-            current_architecture = "amd64" if conditional_architecture == "arm64" else "arm64"
-            index += 1
-            continue
-        if re.fullmatch(r"    end\n?", lines[index]):
-            current_architecture = None
-            conditional_architecture = None
-            index += 1
-            continue
-
-        url_match = re.fullmatch(r'(\s+)url "[^"]+"\n?', lines[index])
-        if not url_match:
-            index += 1
-            continue
-        if current_architecture is None or index + 1 >= len(lines):
-            raise SystemExit(f"explicit-assets mode could not bind a {stanza} URL to an architecture predicate")
-        sha_match = re.fullmatch(r'(\s+)sha256 "[0-9a-f]+"\n?', lines[index + 1])
-        if not sha_match or sha_match.group(1) != url_match.group(1):
-            raise SystemExit(f"explicit-assets mode requires adjacent URL/checksum pairs in {stanza}")
-
-        target = f"{prefix}_{current_architecture}"
-        if target in seen_targets:
-            raise SystemExit(f"explicit-assets mode found duplicate {target} URL/checksum pairs")
-        item = assets[target]
-        newline = "\n" if lines[index].endswith("\n") else ""
-        indentation = url_match.group(1)
-        lines[index] = f'{indentation}url "{explicit_asset_url(repository, tag, item["name"])}"{newline}'
-        lines[index + 1] = f'{indentation}sha256 "{item["sha256"]}"{newline}'
-        seen_targets.add(target)
-        index += 2
-
-    expected_targets = {f"{prefix}_arm64", f"{prefix}_amd64"}
-    if seen_targets != expected_targets:
-        raise SystemExit(f"explicit-assets mode requires exact arm64 and amd64 pairs in {stanza}")
+        raise SystemExit(f"{mode} requires exact arm64 and amd64 pairs in {stanza}")
     body = "".join(lines)
     return text[: match.start("body")] + body + text[match.end("body") :]
 
@@ -945,28 +854,15 @@ def render_verified_target_formula(
 ) -> str:
     text = update_repository_metadata(text, repository)
     text = update_version(text, version)
-    text = update_verified_stanza(
-        text,
-        "on_macos",
-        repository,
-        tag,
-        formula,
-        version,
-        template,
-        target_aliases,
-        hashes,
-    )
-    text = update_verified_stanza(
-        text,
-        "on_linux",
-        repository,
-        tag,
-        formula,
-        version,
-        template,
-        target_aliases,
-        hashes,
-    )
+    assets = {
+        target: (
+            interpolated_target_url(repository, tag, formula, version, template, target_aliases, target),
+            hashes[target],
+        )
+        for target in RELEASE_TARGETS
+    }
+    for stanza in ("on_macos", "on_linux"):
+        text = update_target_stanza(text, stanza, assets, "verified-hash mode")
 
     version_lines = re.findall(r"^\s*version(?:\s|$).*$", text, flags=re.MULTILINE)
     if version_lines and version_lines != [f'  version "{version}"']:
@@ -1000,8 +896,12 @@ def render_explicit_target_formula(
 ) -> str:
     text = update_repository_metadata(text, repository)
     text = update_version(text, version)
-    text = update_explicit_stanza(text, "on_macos", repository, tag, assets)
-    text = update_explicit_stanza(text, "on_linux", repository, tag, assets)
+    target_assets = {
+        target: (explicit_asset_url(repository, tag, item["name"]), item["sha256"])
+        for target, item in assets.items()
+    }
+    for stanza in ("on_macos", "on_linux"):
+        text = update_target_stanza(text, stanza, target_assets, "explicit-assets mode")
     actual_pairs = sorted(
         (match.group("url").replace("#{version}", version), match.group("sha"))
         for stanza in ("on_macos", "on_linux")


### PR DESCRIPTION
The explicit-assets and verified-hash update paths duplicated the same architecture walker. Use one parser with a precomputed URL/checksum inventory while retaining each contract's URL rendering, diagnostics and final inventory checks. Also reuse the stanza matcher and token pattern, and remove an unused checksum helper and inference argument. No formula versions or CLI contracts change.

Validation: all 73 Python tests pass (`python3 -B -m unittest discover -s tests -q`); all four Homebrew OCM platform simulations pass (`brew ruby tests/test_ocm_platforms.rb`); `git diff --check` passes. Isolated Codex autoreview at P0–P2: scoped-clean.

Live proof: ran the updater against a temporary copy of `Formula/crabfleet.rb` with `--formula crabfleet --tag v0.3.1 --repository openclaw/crabfleet --assets-json <inventory from the checked-in formula>`. It downloaded and hashed all four public release archives, matched each checked-in digest, produced the exact expected release inventory and preserved the install/test body. No live tap publication was invoked.

```text
verified darwin_amd64: 0874fd96baf310d77dd4c4b15697a3665498d2eb56e102edccffb9151c2f0c1e
verified darwin_arm64: 7eae01c94c918dc5d26a386a16d31cc5861f94c42b038368ad032d94129a1552
verified linux_amd64: e8ca5e6ebf7d0ce2155753c29f8b0de90cb0f4d31f8d7b217eaebbb9788fcf18
verified linux_arm64: 8306fe50c02daddd880ca46c1f887a1110d34ddf8b4668952649b8bb6c778a0a
PASS: all four public archives hashed; exact metadata and install/test body preserved
```
