### PR TITLE
refactor: separate formula text editing from release I/O

### DIFF
--- a/.github/scripts/formula_text.py
+++ b/.github/scripts/formula_text.py
@@ -1,0 +1,590 @@
+"""Pure Homebrew formula text parsing and rendering; no downloads or file writes."""
+
+from __future__ import annotations
+
+import re
+
+
+RELEASE_TARGETS = ("darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64")
+
+
+def ruby_string(value: str) -> str:
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("#{", "\\#{")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
+    return f'"{escaped}"'
+
+
+def replace_once(text: str, pattern: str, replacement: str, description: str) -> str:
+    matches = re.findall(pattern, text, flags=re.MULTILINE | re.DOTALL)
+    if len(matches) != 1:
+        raise SystemExit(f"expected exactly one {description}, found {len(matches)}")
+    return re.sub(pattern, replacement, text, count=1, flags=re.MULTILINE | re.DOTALL)
+
+
+def replace_zero_or_one(text: str, pattern: str, replacement: str, description: str) -> str:
+    matches = re.findall(pattern, text, flags=re.MULTILINE | re.DOTALL)
+    if len(matches) > 1:
+        raise SystemExit(f"expected at most one {description}, found {len(matches)}")
+    if not matches:
+        print(f"no explicit {description}; leaving it unchanged")
+        return text
+    return re.sub(pattern, replacement, text, count=1, flags=re.MULTILINE | re.DOTALL)
+
+
+def target_markers(target: str, alias: str | None = None) -> tuple[str, ...]:
+    markers = {target, target.replace("_", "-")}
+    if target == "darwin_amd64":
+        markers.update(("macos-x86_64", "macos-amd64", "darwin-x86_64", "x86_64-apple-darwin"))
+    elif target == "darwin_arm64":
+        markers.update(("macos-arm64", "darwin-aarch64", "aarch64-apple-darwin"))
+    elif target == "linux_amd64":
+        markers.update(("linux-x86_64", "linux-amd64", "x86_64-unknown-linux-gnu"))
+    elif target == "linux_arm64":
+        markers.update(("linux-aarch64", "linux-arm64"))
+    elif target == "darwin_universal":
+        markers.update(("macos-universal", "darwin-universal"))
+    if alias:
+        markers.add(alias)
+    return tuple(sorted(markers, key=len, reverse=True))
+
+
+def classify_target(url: str, aliases: dict[str, str], version: str) -> str | None:
+    expanded = url.replace("#{version}", version)
+    for target in ("darwin_universal", "darwin_arm64", "darwin_amd64", "linux_arm64", "linux_amd64"):
+        for marker in target_markers(target, aliases.get(target)):
+            if marker in expanded:
+                return target
+    return None
+
+
+def iter_url_sha_pairs(text: str) -> list[re.Match[str]]:
+    return list(
+        re.finditer(
+            r'(?P<prefix>url ")(?P<url>[^"]+)'
+            r'(?P<middle>"\n(?:[ \t]+version "[^"\n]+"\n)?\s+sha256 ")'
+            r'(?P<sha>[0-9a-f]+)(?P<suffix>")',
+            text,
+            flags=re.MULTILINE,
+        )
+    )
+
+
+def iter_primary_url_sha_pairs(text: str) -> list[re.Match[str]]:
+    resources = list(re.finditer(
+        r'^(?P<indent>[ \t]+)resource [^\n]+\n.*?^(?P=indent)end(?:[ \t]*\n|$)',
+        text,
+        re.MULTILINE | re.DOTALL,
+    ))
+    return [
+        pair for pair in iter_url_sha_pairs(text)
+        if not any(resource.start() <= pair.start() < resource.end() for resource in resources)
+    ]
+
+
+def stanza_body(text: str, stanza: str) -> str | None:
+    match = stanza_match(text, stanza)
+    return match.group("body") if match else None
+
+
+def stanza_url_shape_count(text: str, stanza: str, version: str) -> int:
+    body = stanza_body(text, stanza)
+    if body is None:
+        return 0
+
+    pairs = iter_url_sha_pairs(body)
+    return len({pair.group("url").replace("#{version}", version) for pair in pairs})
+
+
+def uses_stanza_url_mode(text: str, version: str) -> bool:
+    if not (has_stanza(text, "on_macos") and has_stanza(text, "on_linux")):
+        return False
+    return all(stanza_url_shape_count(text, stanza, version) <= 1 for stanza in ("on_macos", "on_linux"))
+
+
+def stanza_match(text: str, stanza: str) -> re.Match[str] | None:
+    return re.search(
+        rf'(?P<header>^\s*{stanza}\s+do\s*$\n)(?P<body>.*?)(?=^\s*(?:on_macos\s+do|on_linux\s+do|resource\s+|head |def |test do))',
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+
+
+def replace_url_preserving_interpolation(
+    text: str,
+    pattern: str,
+    url: str,
+    version: str,
+    description: str,
+) -> str:
+    matches = list(re.finditer(pattern, text, flags=re.MULTILINE | re.DOTALL))
+    if len(matches) != 1:
+        raise SystemExit(f"expected exactly one {description}, found {len(matches)}")
+
+    match = matches[0]
+    existing_url = match.group("url")
+    if "#{version}" in existing_url and existing_url.replace("#{version}", version) == url:
+        print(f"{description} uses #{{version}} interpolation; leaving it unchanged")
+        return text
+
+    return text[: match.start("url")] + url + text[match.end("url") :]
+
+
+def update_url_and_sha_in_stanza(text: str, stanza: str, url: str, digest: str, version: str) -> str:
+    match = stanza_match(text, stanza)
+    if not match:
+        return text
+
+    body = match.group("body")
+    pairs = iter_url_sha_pairs(body)
+    if not pairs:
+        raise SystemExit(f"expected at least one url/sha256 pair in {stanza} stanza")
+
+    expanded_urls = {pair.group("url").replace("#{version}", version) for pair in pairs}
+    if len(expanded_urls) > 1:
+        raise SystemExit(
+            f"expected one source URL shape in {stanza} stanza, found {len(expanded_urls)}; "
+            "formulae with multiple architecture-specific checksums need manual updates"
+        )
+
+    replacements: list[tuple[int, int, str]] = []
+    for pair in pairs:
+        existing_url = pair.group("url")
+        replacement_url = url
+        if "#{version}" in existing_url and existing_url.replace("#{version}", version) == url:
+            replacement_url = existing_url
+        replacements.append(
+            (
+                pair.start(),
+                pair.end(),
+                f'{pair.group("prefix")}{replacement_url}{pair.group("middle")}{digest}{pair.group("suffix")}',
+            )
+        )
+
+    for start, end, replacement in reversed(replacements):
+        body = body[:start] + replacement + body[end:]
+
+    return text[: match.start("body")] + body + text[match.end("body") :]
+
+
+def has_stanza(text: str, stanza: str) -> bool:
+    return stanza_body(text, stanza) is not None
+
+
+def ruby_class_name(formula: str) -> str:
+    return "".join(part.capitalize() for part in re.split(r"[-_]+", formula) if part)
+
+
+def seed_formula(formula: str, repository: str, version: str, description: str, template: str) -> str:
+    def url(target: str) -> str:
+        artifact = template.format(
+            formula=formula,
+            version="#{version}",
+            tag=f"v{version}",
+            target=target,
+        )
+        return f"https://github.com/{repository}/releases/download/v#{{version}}/{artifact}"
+
+    class_name = ruby_class_name(formula)
+    return f'''class {class_name} < Formula
+  desc {ruby_string(description)}
+  homepage "https://github.com/{repository}"
+  version "{version}"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "{url("darwin_arm64")}"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    else
+      url "{url("darwin_amd64")}"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "{url("linux_arm64")}"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    else
+      url "{url("linux_amd64")}"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  def install
+    bin.install "{formula}"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{{bin}}/{formula} --version")
+  end
+end
+'''
+
+
+def target_url(
+    repository: str,
+    tag: str,
+    formula: str,
+    version: str,
+    template: str,
+    target_aliases: dict[str, str],
+    target: str,
+) -> str:
+    artifact_target = target_aliases.get(target, target)
+    artifact = template.format(
+        formula=formula,
+        version=version,
+        tag=tag,
+        target=artifact_target,
+    )
+    return f"https://github.com/{repository}/releases/download/{tag}/{artifact}"
+
+
+def interpolated_target_url(
+    repository: str,
+    tag: str,
+    formula: str,
+    version: str,
+    template: str,
+    target_aliases: dict[str, str],
+    target: str,
+) -> str:
+    artifact_target = target_aliases.get(target, target)
+    interpolated_version = "#{version}"
+    interpolated_tag = f"v{interpolated_version}" if tag == f"v{version}" else interpolated_version
+    artifact = template.format(
+        formula=formula,
+        version=interpolated_version,
+        tag=interpolated_tag,
+        target=artifact_target,
+    )
+    return f"https://github.com/{repository}/releases/download/{interpolated_tag}/{artifact}"
+
+
+def predicate_architecture(line: str) -> str | None:
+    match = re.fullmatch(
+        r"    (?:if|elsif) Hardware::CPU\.(arm|intel)\?(?: && Hardware::CPU\.is_64_bit\?)?\n?",
+        line,
+    )
+    if match:
+        return "arm64" if match.group(1) == "arm" else "amd64"
+    match = re.fullmatch(r"    on_(arm|intel) do\n?", line)
+    if match:
+        return "arm64" if match.group(1) == "arm" else "amd64"
+    return None
+
+
+def update_target_stanza(
+    text: str,
+    stanza: str,
+    assets: dict[str, tuple[str, str]],
+    mode: str,
+) -> str:
+    matches = list(re.finditer(rf"^  {stanza} do$", text, flags=re.MULTILINE))
+    match = stanza_match(text, stanza)
+    if len(matches) != 1 or match is None:
+        raise SystemExit(f"{mode} requires exactly one {stanza} stanza")
+
+    prefix = "darwin" if stanza == "on_macos" else "linux"
+    lines = match.group("body").splitlines(keepends=True)
+    current_architecture: str | None = None
+    conditional_architecture: str | None = None
+    seen_targets: set[str] = set()
+    index = 0
+    while index < len(lines):
+        architecture = predicate_architecture(lines[index])
+        if architecture:
+            current_architecture = architecture
+            conditional_architecture = architecture
+            index += 1
+            continue
+        if re.fullmatch(r"    else\n?", lines[index]):
+            if conditional_architecture is None:
+                raise SystemExit(f"{mode} found an unmatched else in {stanza}")
+            current_architecture = "amd64" if conditional_architecture == "arm64" else "arm64"
+            index += 1
+            continue
+        if re.fullmatch(r"    end\n?", lines[index]):
+            current_architecture = None
+            conditional_architecture = None
+            index += 1
+            continue
+
+        url_match = re.fullmatch(r'(\s+)url "[^"]+"\n?', lines[index])
+        if not url_match:
+            index += 1
+            continue
+        if current_architecture is None or index + 1 >= len(lines):
+            raise SystemExit(f"{mode} could not bind a {stanza} URL to an architecture predicate")
+        sha_match = re.fullmatch(r'(\s+)sha256 "[0-9a-f]+"\n?', lines[index + 1])
+        if not sha_match or sha_match.group(1) != url_match.group(1):
+            raise SystemExit(f"{mode} requires adjacent URL/checksum pairs in {stanza}")
+
+        target = f"{prefix}_{current_architecture}"
+        if target in seen_targets:
+            raise SystemExit(f"{mode} found duplicate {target} URL/checksum pairs")
+        newline = "\n" if lines[index].endswith("\n") else ""
+        indentation = url_match.group(1)
+        url, digest = assets[target]
+        lines[index] = f'{indentation}url "{url}"{newline}'
+        lines[index + 1] = f'{indentation}sha256 "{digest}"{newline}'
+        seen_targets.add(target)
+        index += 2
+
+    expected_targets = {f"{prefix}_arm64", f"{prefix}_amd64"}
+    if seen_targets != expected_targets:
+        raise SystemExit(f"{mode} requires exact arm64 and amd64 pairs in {stanza}")
+    body = "".join(lines)
+    return text[: match.start("body")] + body + text[match.end("body") :]
+
+
+def target_stanza(
+    stanza: str,
+    first_target: str,
+    second_target: str,
+    repository: str,
+    tag: str,
+    formula: str,
+    version: str,
+    template: str,
+    target_aliases: dict[str, str],
+) -> str:
+    first_url = target_url(repository, tag, formula, version, template, target_aliases, first_target)
+    second_url = target_url(repository, tag, formula, version, template, target_aliases, second_target)
+    first_predicate = "Hardware::CPU.arm?" if first_target.endswith("arm64") else "Hardware::CPU.intel?"
+    second_predicate = "Hardware::CPU.intel?" if second_target.endswith("amd64") else "Hardware::CPU.arm?"
+    if stanza == "on_linux":
+        first_predicate = f"{first_predicate} && Hardware::CPU.is_64_bit?"
+        second_predicate = f"{second_predicate} && Hardware::CPU.is_64_bit?"
+
+    return f'''  {stanza} do
+    if {first_predicate}
+      url "{first_url}"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+
+    if {second_predicate}
+      url "{second_url}"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+'''
+
+
+def convert_stanza_url_mode_to_targets(
+    text: str,
+    repository: str,
+    tag: str,
+    formula: str,
+    version: str,
+    template: str,
+    target_aliases: dict[str, str],
+) -> str:
+    replacements = {
+        "on_macos": target_stanza(
+            "on_macos",
+            "darwin_arm64",
+            "darwin_amd64",
+            repository,
+            tag,
+            formula,
+            version,
+            template,
+            target_aliases,
+        ),
+        "on_linux": target_stanza(
+            "on_linux",
+            "linux_arm64",
+            "linux_amd64",
+            repository,
+            tag,
+            formula,
+            version,
+            template,
+            target_aliases,
+        ),
+    }
+
+    for stanza, replacement in replacements.items():
+        match = stanza_match(text, stanza)
+        if not match:
+            raise SystemExit(f"expected {stanza} stanza for target conversion")
+        text = text[: match.start()] + replacement + text[match.end() :]
+    return text
+
+
+def remove_stanza(text: str, stanza: str) -> str:
+    match = stanza_match(text, stanza)
+    if not match:
+        return text
+    return text[: match.start()] + text[match.end() :]
+
+
+def remove_top_level_url_sha(text: str) -> str:
+    return re.sub(
+        r'^\s*url\s+"[^"]+"\n\s*sha256\s+"[0-9a-f]+"\n',
+        "",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+
+def insert_target_stanzas(
+    text: str,
+    repository: str,
+    tag: str,
+    formula: str,
+    version: str,
+    template: str,
+    target_aliases: dict[str, str],
+) -> str:
+    text = remove_stanza(text, "on_macos")
+    text = remove_stanza(text, "on_linux")
+    text = remove_top_level_url_sha(text)
+
+    stanzas = (
+        "\n"
+        + target_stanza(
+            "on_macos",
+            "darwin_arm64",
+            "darwin_amd64",
+            repository,
+            tag,
+            formula,
+            version,
+            template,
+            target_aliases,
+        )
+        + "\n"
+        + target_stanza(
+            "on_linux",
+            "linux_arm64",
+            "linux_amd64",
+            repository,
+            tag,
+            formula,
+            version,
+            template,
+            target_aliases,
+        )
+    )
+
+    match = re.search(r'^(\s*license\s+"[^"]+"\n)', text, flags=re.MULTILINE)
+    if not match:
+        raise SystemExit("target conversion requires a license line")
+    return text[: match.end()] + stanzas + text[match.end() :]
+
+
+def render_verified_target_formula(
+    text: str,
+    repository: str,
+    tag: str,
+    formula: str,
+    version: str,
+    template: str,
+    target_aliases: dict[str, str],
+    hashes: dict[str, str],
+) -> str:
+    text = update_repository_metadata(text, repository)
+    text = update_version(text, version)
+    assets = {
+        target: (
+            interpolated_target_url(repository, tag, formula, version, template, target_aliases, target),
+            hashes[target],
+        )
+        for target in RELEASE_TARGETS
+    }
+    for stanza in ("on_macos", "on_linux"):
+        text = update_target_stanza(text, stanza, assets, "verified-hash mode")
+
+    version_lines = re.findall(r"^\s*version(?:\s|$).*$", text, flags=re.MULTILINE)
+    if version_lines and version_lines != [f'  version "{version}"']:
+        raise SystemExit(
+            "verified-hash mode requires zero or one canonical formula version line "
+            "matching the requested version"
+        )
+
+    actual_pairs = [
+        (match.group("url").replace("#{version}", version), match.group("sha"))
+        for match in iter_url_sha_pairs(text)
+    ]
+    expected_pairs = [
+        (
+            target_url(repository, tag, formula, version, template, target_aliases, target),
+            hashes[target],
+        )
+        for target in RELEASE_TARGETS
+    ]
+    if sorted(actual_pairs) != sorted(expected_pairs):
+        raise SystemExit("verified-hash rendering did not produce the exact canonical target URL/checksum inventory")
+    return text
+
+
+def render_explicit_target_formula(
+    text: str,
+    repository: str,
+    version: str,
+    target_assets: dict[str, tuple[str, str]],
+) -> str:
+    text = update_repository_metadata(text, repository)
+    text = update_version(text, version)
+    for stanza in ("on_macos", "on_linux"):
+        text = update_target_stanza(text, stanza, target_assets, "explicit-assets mode")
+    actual_pairs = sorted(
+        (match.group("url").replace("#{version}", version), match.group("sha"))
+        for stanza in ("on_macos", "on_linux")
+        for match in iter_url_sha_pairs(stanza_body(text, stanza) or "")
+    )
+    expected_pairs = sorted(target_assets[target] for target in RELEASE_TARGETS)
+    if actual_pairs != expected_pairs:
+        raise SystemExit("explicit-assets rendering did not produce the exact target URL/checksum inventory")
+    return text
+
+
+def update_top_level_url_and_sha(text: str, url: str, digest: str, version: str) -> str:
+    text = replace_url_preserving_interpolation(
+        text,
+        r'^(?P<prefix>\s*url\s+")(?P<url>[^"]+)(?P<suffix>")',
+        url,
+        version,
+        "top-level url",
+    )
+    return replace_once(
+        text,
+        r'^(\s*sha256\s+")[^"]+(")',
+        rf'\g<1>{digest}\2',
+        "top-level sha256",
+    )
+
+
+def update_version(text: str, version: str) -> str:
+    return replace_zero_or_one(
+        text,
+        r'^(\s*version\s+")[^"]+(")',
+        rf'\g<1>{version}\2',
+        "version",
+    )
+
+
+def update_repository_metadata(text: str, repository: str) -> str:
+    homepage = f"https://github.com/{repository}"
+    head = f"{homepage}.git"
+    text = replace_zero_or_one(
+        text,
+        r'^(?P<prefix>\s*homepage\s+")[^"]+(?P<suffix>")',
+        rf'\g<prefix>{homepage}\g<suffix>',
+        "homepage",
+    )
+    return replace_zero_or_one(
+        text,
+        r'^(?P<prefix>\s*head\s+")[^"]+(?P<suffix>"(?:,\s*branch:\s*"[^"]+")?)',
+        rf'\g<prefix>{head}\g<suffix>',
+        "head",
+    )

--- a/.github/scripts/reconcile_formulae.py
+++ b/.github/scripts/reconcile_formulae.py
@@ -19,6 +19,7 @@ import urllib.request
 from collections.abc import Callable
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import formula_text
 import update_formula
 
 
@@ -116,7 +117,7 @@ def parse_semver(value: str) -> SemanticVersion:
 def source_release_urls(text: str, repository: str, version: str) -> list[tuple[str, str]]:
     prefix = f"https://github.com/{repository}/releases/download/"
     urls: list[tuple[str, str]] = []
-    for pair in update_formula.iter_url_sha_pairs(text):
+    for pair in formula_text.iter_url_sha_pairs(text):
         url = pair.group("url").replace("#{version}", version)
         if not url.lower().startswith(prefix.lower()):
             continue
@@ -129,7 +130,7 @@ def source_release_urls(text: str, repository: str, version: str) -> list[tuple[
 
 
 def marker_for_target(asset: str, target: str) -> str:
-    matches = [marker for marker in update_formula.target_markers(target) if marker in asset]
+    matches = [marker for marker in formula_text.target_markers(target) if marker in asset]
     if not matches:
         raise ValueError(f"cannot identify the {target} marker in {asset!r}")
     return matches[0]
@@ -166,7 +167,7 @@ def infer_update_options(
     for tag, asset in release_urls:
         if tag != current_tag:
             raise ValueError(f"release URL tag {tag!r} does not match current tag {current_tag!r}")
-        target = update_formula.classify_target(asset, {}, version)
+        target = formula_text.classify_target(asset, {}, version)
         if target not in update_formula.RELEASE_TARGETS:
             raise ValueError(f"cannot classify release asset {asset!r}")
         if target in targets:

--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -24,6 +24,10 @@ import urllib.parse
 import urllib.request
 
 
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import formula_text
+
+
 USER_AGENT = "steipete-homebrew-tap-updater"
 DOWNLOAD_TIMEOUT_SECONDS = 30
 GIT_NETWORK_TIMEOUT_SECONDS = 60
@@ -34,7 +38,7 @@ ARTIFACT_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9+@._-]*")
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 GIT_OBJECT_PATTERN = re.compile(r"[0-9a-f]{40}")
 REQUEST_ID_PATTERN = re.compile(r"[A-Za-z0-9][-A-Za-z0-9._:]{0,127}")
-RELEASE_TARGETS = ("darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64")
+RELEASE_TARGETS = formula_text.RELEASE_TARGETS
 CANONICAL_TARGETS = frozenset(("darwin_universal", *RELEASE_TARGETS))
 TEMPLATE_FIELDS = frozenset(("formula", "version", "tag", "target"))
 
@@ -171,17 +175,6 @@ def tap_path(directory: str, token: str) -> pathlib.Path:
     if (pathlib.Path.cwd() / relative).resolve().parent != expected_parent:
         raise SystemExit(f"invalid {directory} path for {token!r}")
     return relative
-
-
-def ruby_string(value: str) -> str:
-    escaped = (
-        value.replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("#{", "\\#{")
-        .replace("\r", "\\r")
-        .replace("\n", "\\n")
-    )
-    return f'"{escaped}"'
 
 
 class DownloadRedirectHandler(urllib.request.HTTPRedirectHandler):
@@ -338,23 +331,6 @@ def verify_remote_source_tag(
     validate_source_tag_refs(output, tag, source_tag_object, source_tag_commit)
 
 
-def replace_once(text: str, pattern: str, replacement: str, description: str) -> str:
-    matches = re.findall(pattern, text, flags=re.MULTILINE | re.DOTALL)
-    if len(matches) != 1:
-        raise SystemExit(f"expected exactly one {description}, found {len(matches)}")
-    return re.sub(pattern, replacement, text, count=1, flags=re.MULTILINE | re.DOTALL)
-
-
-def replace_zero_or_one(text: str, pattern: str, replacement: str, description: str) -> str:
-    matches = re.findall(pattern, text, flags=re.MULTILINE | re.DOTALL)
-    if len(matches) > 1:
-        raise SystemExit(f"expected at most one {description}, found {len(matches)}")
-    if not matches:
-        print(f"no explicit {description}; leaving it unchanged")
-        return text
-    return re.sub(pattern, replacement, text, count=1, flags=re.MULTILINE | re.DOTALL)
-
-
 def format_template(value: str, formula: str, version: str, tag: str, target: str | None = None) -> str:
     replacements = {
         "formula": formula,
@@ -396,551 +372,6 @@ def parse_target_aliases(value: str | None) -> dict[str, str]:
     return aliases
 
 
-def target_markers(target: str, alias: str | None = None) -> tuple[str, ...]:
-    markers = {target, target.replace("_", "-")}
-    if target == "darwin_amd64":
-        markers.update(("macos-x86_64", "macos-amd64", "darwin-x86_64", "x86_64-apple-darwin"))
-    elif target == "darwin_arm64":
-        markers.update(("macos-arm64", "darwin-aarch64", "aarch64-apple-darwin"))
-    elif target == "linux_amd64":
-        markers.update(("linux-x86_64", "linux-amd64", "x86_64-unknown-linux-gnu"))
-    elif target == "linux_arm64":
-        markers.update(("linux-aarch64", "linux-arm64"))
-    elif target == "darwin_universal":
-        markers.update(("macos-universal", "darwin-universal"))
-    if alias:
-        markers.add(alias)
-    return tuple(sorted(markers, key=len, reverse=True))
-
-
-def classify_target(url: str, aliases: dict[str, str], version: str) -> str | None:
-    expanded = url.replace("#{version}", version)
-    for target in ("darwin_universal", "darwin_arm64", "darwin_amd64", "linux_arm64", "linux_amd64"):
-        for marker in target_markers(target, aliases.get(target)):
-            if marker in expanded:
-                return target
-    return None
-
-
-def iter_url_sha_pairs(text: str) -> list[re.Match[str]]:
-    return list(
-        re.finditer(
-            r'(?P<prefix>url ")(?P<url>[^"]+)'
-            r'(?P<middle>"\n(?:[ \t]+version "[^"\n]+"\n)?\s+sha256 ")'
-            r'(?P<sha>[0-9a-f]+)(?P<suffix>")',
-            text,
-            flags=re.MULTILINE,
-        )
-    )
-
-
-def iter_primary_url_sha_pairs(text: str) -> list[re.Match[str]]:
-    resources = list(re.finditer(
-        r'^(?P<indent>[ \t]+)resource [^\n]+\n.*?^(?P=indent)end(?:[ \t]*\n|$)',
-        text,
-        re.MULTILINE | re.DOTALL,
-    ))
-    return [
-        pair for pair in iter_url_sha_pairs(text)
-        if not any(resource.start() <= pair.start() < resource.end() for resource in resources)
-    ]
-
-
-def stanza_body(text: str, stanza: str) -> str | None:
-    match = stanza_match(text, stanza)
-    return match.group("body") if match else None
-
-
-def stanza_url_shape_count(text: str, stanza: str, version: str) -> int:
-    body = stanza_body(text, stanza)
-    if body is None:
-        return 0
-
-    pairs = iter_url_sha_pairs(body)
-    return len({pair.group("url").replace("#{version}", version) for pair in pairs})
-
-
-def uses_stanza_url_mode(text: str, version: str) -> bool:
-    if not (has_stanza(text, "on_macos") and has_stanza(text, "on_linux")):
-        return False
-    return all(stanza_url_shape_count(text, stanza, version) <= 1 for stanza in ("on_macos", "on_linux"))
-
-
-def stanza_match(text: str, stanza: str) -> re.Match[str] | None:
-    return re.search(
-        rf'(?P<header>^\s*{stanza}\s+do\s*$\n)(?P<body>.*?)(?=^\s*(?:on_macos\s+do|on_linux\s+do|resource\s+|head |def |test do))',
-        text,
-        flags=re.MULTILINE | re.DOTALL,
-    )
-
-
-def replace_url_preserving_interpolation(
-    text: str,
-    pattern: str,
-    url: str,
-    version: str,
-    description: str,
-) -> str:
-    matches = list(re.finditer(pattern, text, flags=re.MULTILINE | re.DOTALL))
-    if len(matches) != 1:
-        raise SystemExit(f"expected exactly one {description}, found {len(matches)}")
-
-    match = matches[0]
-    existing_url = match.group("url")
-    if "#{version}" in existing_url and existing_url.replace("#{version}", version) == url:
-        print(f"{description} uses #{{version}} interpolation; leaving it unchanged")
-        return text
-
-    return text[: match.start("url")] + url + text[match.end("url") :]
-
-
-def update_url_and_sha_in_stanza(text: str, stanza: str, url: str, digest: str, version: str) -> str:
-    match = stanza_match(text, stanza)
-    if not match:
-        return text
-
-    body = match.group("body")
-    pairs = iter_url_sha_pairs(body)
-    if not pairs:
-        raise SystemExit(f"expected at least one url/sha256 pair in {stanza} stanza")
-
-    expanded_urls = {pair.group("url").replace("#{version}", version) for pair in pairs}
-    if len(expanded_urls) > 1:
-        raise SystemExit(
-            f"expected one source URL shape in {stanza} stanza, found {len(expanded_urls)}; "
-            "formulae with multiple architecture-specific checksums need manual updates"
-        )
-
-    replacements: list[tuple[int, int, str]] = []
-    for pair in pairs:
-        existing_url = pair.group("url")
-        replacement_url = url
-        if "#{version}" in existing_url and existing_url.replace("#{version}", version) == url:
-            replacement_url = existing_url
-        replacements.append(
-            (
-                pair.start(),
-                pair.end(),
-                f'{pair.group("prefix")}{replacement_url}{pair.group("middle")}{digest}{pair.group("suffix")}',
-            )
-        )
-
-    for start, end, replacement in reversed(replacements):
-        body = body[:start] + replacement + body[end:]
-
-    return text[: match.start("body")] + body + text[match.end("body") :]
-
-
-def has_stanza(text: str, stanza: str) -> bool:
-    return stanza_body(text, stanza) is not None
-
-
-def ruby_class_name(formula: str) -> str:
-    return "".join(part.capitalize() for part in re.split(r"[-_]+", formula) if part)
-
-
-def seed_formula(formula: str, repository: str, version: str, description: str, template: str) -> str:
-    def url(target: str) -> str:
-        artifact = template.format(
-            formula=formula,
-            version="#{version}",
-            tag=f"v{version}",
-            target=target,
-        )
-        return f"https://github.com/{repository}/releases/download/v#{{version}}/{artifact}"
-
-    class_name = ruby_class_name(formula)
-    return f'''class {class_name} < Formula
-  desc {ruby_string(description)}
-  homepage "https://github.com/{repository}"
-  version "{version}"
-  license "MIT"
-
-  on_macos do
-    if Hardware::CPU.arm?
-      url "{url("darwin_arm64")}"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
-    else
-      url "{url("darwin_amd64")}"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
-    end
-  end
-
-  on_linux do
-    if Hardware::CPU.arm?
-      url "{url("linux_arm64")}"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
-    else
-      url "{url("linux_amd64")}"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
-    end
-  end
-
-  def install
-    bin.install "{formula}"
-  end
-
-  test do
-    assert_match version.to_s, shell_output("#{{bin}}/{formula} --version")
-  end
-end
-'''
-
-
-def target_url(
-    repository: str,
-    tag: str,
-    formula: str,
-    version: str,
-    template: str,
-    target_aliases: dict[str, str],
-    target: str,
-) -> str:
-    artifact_target = target_aliases.get(target, target)
-    artifact = template.format(
-        formula=formula,
-        version=version,
-        tag=tag,
-        target=artifact_target,
-    )
-    return f"https://github.com/{repository}/releases/download/{tag}/{artifact}"
-
-
-def interpolated_target_url(
-    repository: str,
-    tag: str,
-    formula: str,
-    version: str,
-    template: str,
-    target_aliases: dict[str, str],
-    target: str,
-) -> str:
-    artifact_target = target_aliases.get(target, target)
-    interpolated_version = "#{version}"
-    interpolated_tag = f"v{interpolated_version}" if tag == f"v{version}" else interpolated_version
-    artifact = template.format(
-        formula=formula,
-        version=interpolated_version,
-        tag=interpolated_tag,
-        target=artifact_target,
-    )
-    return f"https://github.com/{repository}/releases/download/{interpolated_tag}/{artifact}"
-
-
-def predicate_architecture(line: str) -> str | None:
-    match = re.fullmatch(
-        r"    (?:if|elsif) Hardware::CPU\.(arm|intel)\?(?: && Hardware::CPU\.is_64_bit\?)?\n?",
-        line,
-    )
-    if match:
-        return "arm64" if match.group(1) == "arm" else "amd64"
-    match = re.fullmatch(r"    on_(arm|intel) do\n?", line)
-    if match:
-        return "arm64" if match.group(1) == "arm" else "amd64"
-    return None
-
-
-def update_target_stanza(
-    text: str,
-    stanza: str,
-    assets: dict[str, tuple[str, str]],
-    mode: str,
-) -> str:
-    matches = list(re.finditer(rf"^  {stanza} do$", text, flags=re.MULTILINE))
-    match = stanza_match(text, stanza)
-    if len(matches) != 1 or match is None:
-        raise SystemExit(f"{mode} requires exactly one {stanza} stanza")
-
-    prefix = "darwin" if stanza == "on_macos" else "linux"
-    lines = match.group("body").splitlines(keepends=True)
-    current_architecture: str | None = None
-    conditional_architecture: str | None = None
-    seen_targets: set[str] = set()
-    index = 0
-    while index < len(lines):
-        architecture = predicate_architecture(lines[index])
-        if architecture:
-            current_architecture = architecture
-            conditional_architecture = architecture
-            index += 1
-            continue
-        if re.fullmatch(r"    else\n?", lines[index]):
-            if conditional_architecture is None:
-                raise SystemExit(f"{mode} found an unmatched else in {stanza}")
-            current_architecture = "amd64" if conditional_architecture == "arm64" else "arm64"
-            index += 1
-            continue
-        if re.fullmatch(r"    end\n?", lines[index]):
-            current_architecture = None
-            conditional_architecture = None
-            index += 1
-            continue
-
-        url_match = re.fullmatch(r'(\s+)url "[^"]+"\n?', lines[index])
-        if not url_match:
-            index += 1
-            continue
-        if current_architecture is None or index + 1 >= len(lines):
-            raise SystemExit(f"{mode} could not bind a {stanza} URL to an architecture predicate")
-        sha_match = re.fullmatch(r'(\s+)sha256 "[0-9a-f]+"\n?', lines[index + 1])
-        if not sha_match or sha_match.group(1) != url_match.group(1):
-            raise SystemExit(f"{mode} requires adjacent URL/checksum pairs in {stanza}")
-
-        target = f"{prefix}_{current_architecture}"
-        if target in seen_targets:
-            raise SystemExit(f"{mode} found duplicate {target} URL/checksum pairs")
-        newline = "\n" if lines[index].endswith("\n") else ""
-        indentation = url_match.group(1)
-        url, digest = assets[target]
-        lines[index] = f'{indentation}url "{url}"{newline}'
-        lines[index + 1] = f'{indentation}sha256 "{digest}"{newline}'
-        seen_targets.add(target)
-        index += 2
-
-    expected_targets = {f"{prefix}_arm64", f"{prefix}_amd64"}
-    if seen_targets != expected_targets:
-        raise SystemExit(f"{mode} requires exact arm64 and amd64 pairs in {stanza}")
-    body = "".join(lines)
-    return text[: match.start("body")] + body + text[match.end("body") :]
-
-
-def target_stanza(
-    stanza: str,
-    first_target: str,
-    second_target: str,
-    repository: str,
-    tag: str,
-    formula: str,
-    version: str,
-    template: str,
-    target_aliases: dict[str, str],
-) -> str:
-    first_url = target_url(repository, tag, formula, version, template, target_aliases, first_target)
-    second_url = target_url(repository, tag, formula, version, template, target_aliases, second_target)
-    first_predicate = "Hardware::CPU.arm?" if first_target.endswith("arm64") else "Hardware::CPU.intel?"
-    second_predicate = "Hardware::CPU.intel?" if second_target.endswith("amd64") else "Hardware::CPU.arm?"
-    if stanza == "on_linux":
-        first_predicate = f"{first_predicate} && Hardware::CPU.is_64_bit?"
-        second_predicate = f"{second_predicate} && Hardware::CPU.is_64_bit?"
-
-    return f'''  {stanza} do
-    if {first_predicate}
-      url "{first_url}"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
-    end
-
-    if {second_predicate}
-      url "{second_url}"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
-    end
-  end
-'''
-
-
-def convert_stanza_url_mode_to_targets(
-    text: str,
-    repository: str,
-    tag: str,
-    formula: str,
-    version: str,
-    template: str,
-    target_aliases: dict[str, str],
-) -> str:
-    replacements = {
-        "on_macos": target_stanza(
-            "on_macos",
-            "darwin_arm64",
-            "darwin_amd64",
-            repository,
-            tag,
-            formula,
-            version,
-            template,
-            target_aliases,
-        ),
-        "on_linux": target_stanza(
-            "on_linux",
-            "linux_arm64",
-            "linux_amd64",
-            repository,
-            tag,
-            formula,
-            version,
-            template,
-            target_aliases,
-        ),
-    }
-
-    for stanza, replacement in replacements.items():
-        match = stanza_match(text, stanza)
-        if not match:
-            raise SystemExit(f"expected {stanza} stanza for target conversion")
-        text = text[: match.start()] + replacement + text[match.end() :]
-    return text
-
-
-def remove_stanza(text: str, stanza: str) -> str:
-    match = stanza_match(text, stanza)
-    if not match:
-        return text
-    return text[: match.start()] + text[match.end() :]
-
-
-def remove_top_level_url_sha(text: str) -> str:
-    return re.sub(
-        r'^\s*url\s+"[^"]+"\n\s*sha256\s+"[0-9a-f]+"\n',
-        "",
-        text,
-        count=1,
-        flags=re.MULTILINE,
-    )
-
-
-def insert_target_stanzas(
-    text: str,
-    repository: str,
-    tag: str,
-    formula: str,
-    version: str,
-    template: str,
-    target_aliases: dict[str, str],
-) -> str:
-    text = remove_stanza(text, "on_macos")
-    text = remove_stanza(text, "on_linux")
-    text = remove_top_level_url_sha(text)
-
-    stanzas = (
-        "\n"
-        + target_stanza(
-            "on_macos",
-            "darwin_arm64",
-            "darwin_amd64",
-            repository,
-            tag,
-            formula,
-            version,
-            template,
-            target_aliases,
-        )
-        + "\n"
-        + target_stanza(
-            "on_linux",
-            "linux_arm64",
-            "linux_amd64",
-            repository,
-            tag,
-            formula,
-            version,
-            template,
-            target_aliases,
-        )
-    )
-
-    match = re.search(r'^(\s*license\s+"[^"]+"\n)', text, flags=re.MULTILINE)
-    if not match:
-        raise SystemExit("target conversion requires a license line")
-    return text[: match.end()] + stanzas + text[match.end() :]
-
-
-def render_verified_target_formula(
-    text: str,
-    repository: str,
-    tag: str,
-    formula: str,
-    version: str,
-    template: str,
-    target_aliases: dict[str, str],
-    hashes: dict[str, str],
-) -> str:
-    text = update_repository_metadata(text, repository)
-    text = update_version(text, version)
-    assets = {
-        target: (
-            interpolated_target_url(repository, tag, formula, version, template, target_aliases, target),
-            hashes[target],
-        )
-        for target in RELEASE_TARGETS
-    }
-    for stanza in ("on_macos", "on_linux"):
-        text = update_target_stanza(text, stanza, assets, "verified-hash mode")
-
-    version_lines = re.findall(r"^\s*version(?:\s|$).*$", text, flags=re.MULTILINE)
-    if version_lines and version_lines != [f'  version "{version}"']:
-        raise SystemExit(
-            "verified-hash mode requires zero or one canonical formula version line "
-            "matching the requested version"
-        )
-
-    actual_pairs = [
-        (match.group("url").replace("#{version}", version), match.group("sha"))
-        for match in iter_url_sha_pairs(text)
-    ]
-    expected_pairs = [
-        (
-            target_url(repository, tag, formula, version, template, target_aliases, target),
-            hashes[target],
-        )
-        for target in RELEASE_TARGETS
-    ]
-    if sorted(actual_pairs) != sorted(expected_pairs):
-        raise SystemExit("verified-hash rendering did not produce the exact canonical target URL/checksum inventory")
-    return text
-
-
-def render_explicit_target_formula(
-    text: str,
-    repository: str,
-    tag: str,
-    version: str,
-    assets: dict[str, dict[str, str]],
-) -> str:
-    text = update_repository_metadata(text, repository)
-    text = update_version(text, version)
-    target_assets = {
-        target: (explicit_asset_url(repository, tag, item["name"]), item["sha256"])
-        for target, item in assets.items()
-    }
-    for stanza in ("on_macos", "on_linux"):
-        text = update_target_stanza(text, stanza, target_assets, "explicit-assets mode")
-    actual_pairs = sorted(
-        (match.group("url").replace("#{version}", version), match.group("sha"))
-        for stanza in ("on_macos", "on_linux")
-        for match in iter_url_sha_pairs(stanza_body(text, stanza) or "")
-    )
-    expected_pairs = sorted(
-        (explicit_asset_url(repository, tag, assets[target]["name"]), assets[target]["sha256"])
-        for target in RELEASE_TARGETS
-    )
-    if actual_pairs != expected_pairs:
-        raise SystemExit("explicit-assets rendering did not produce the exact target URL/checksum inventory")
-    return text
-
-
-def update_top_level_url_and_sha(text: str, url: str, digest: str, version: str) -> str:
-    text = replace_url_preserving_interpolation(
-        text,
-        r'^(?P<prefix>\s*url\s+")(?P<url>[^"]+)(?P<suffix>")',
-        url,
-        version,
-        "top-level url",
-    )
-    return replace_once(
-        text,
-        r'^(\s*sha256\s+")[^"]+(")',
-        rf'\g<1>{digest}\2',
-        "top-level sha256",
-    )
-
-
-def update_version(text: str, version: str) -> str:
-    return replace_zero_or_one(
-        text,
-        r'^(\s*version\s+")[^"]+(")',
-        rf'\g<1>{version}\2',
-        "version",
-    )
-
-
 def update_cask(cask: str, repository: str, tag: str, artifact: str) -> None:
     validate_artifact_token(artifact, "cask artifact")
     version = tag[1:] if tag.startswith("v") else tag
@@ -951,28 +382,11 @@ def update_cask(cask: str, repository: str, tag: str, artifact: str) -> None:
         raise SystemExit(f"{path} does not exist; cask creation needs a manual template")
 
     text = path.read_text()
-    text = update_version(text, version)
-    text = update_top_level_url_and_sha(text, url, digest, version)
+    text = formula_text.update_version(text, version)
+    text = formula_text.update_top_level_url_and_sha(text, url, digest, version)
     path.write_text(text)
     print(f"cask: {digest}  {url}")
     print(f"updated {path} to {version}")
-
-
-def update_repository_metadata(text: str, repository: str) -> str:
-    homepage = f"https://github.com/{repository}"
-    head = f"{homepage}.git"
-    text = replace_zero_or_one(
-        text,
-        r'^(?P<prefix>\s*homepage\s+")[^"]+(?P<suffix>")',
-        rf'\g<prefix>{homepage}\g<suffix>',
-        "homepage",
-    )
-    return replace_zero_or_one(
-        text,
-        r'^(?P<prefix>\s*head\s+")[^"]+(?P<suffix>"(?:,\s*branch:\s*"[^"]+")?)',
-        rf'\g<prefix>{head}\g<suffix>',
-        "head",
-    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1149,7 +563,7 @@ def main(argv: list[str] | None = None) -> int:
         path = tap_path("Formula", args.formula)
         if not path.exists():
             raise SystemExit("verified-hash mode updates existing formulae only")
-        text = render_verified_target_formula(
+        text = formula_text.render_verified_target_formula(
             path.read_text(),
             args.repository,
             args.tag,
@@ -1169,7 +583,7 @@ def main(argv: list[str] | None = None) -> int:
             text = path.read_text()
         else:
             description = args.description or f"{args.formula} command-line tool"
-            text = seed_formula(
+            text = formula_text.seed_formula(
                 args.formula,
                 args.repository,
                 version,
@@ -1177,12 +591,14 @@ def main(argv: list[str] | None = None) -> int:
                 "{formula}_{version}_{target}.tar.gz",
             )
         verify_explicit_assets(args.repository, args.tag, explicit_assets)
-        text = render_explicit_target_formula(
+        text = formula_text.render_explicit_target_formula(
             text,
             args.repository,
-            args.tag,
             version,
-            explicit_assets,
+            {
+                target: (explicit_asset_url(args.repository, args.tag, item["name"]), item["sha256"])
+                for target, item in explicit_assets.items()
+            },
         )
         path.write_text(text)
         print(f"updated {path} to {version} from exact verified release assets")
@@ -1216,18 +632,18 @@ def main(argv: list[str] | None = None) -> int:
     else:
         template = args.artifact_template or "{formula}_{version}_{target}.tar.gz"
         description = args.description or f"{args.formula} command-line tool"
-        text = seed_formula(args.formula, args.repository, version, description, template)
+        text = formula_text.seed_formula(args.formula, args.repository, version, description, template)
         created = True
-    text = update_repository_metadata(text, args.repository)
-    text = update_version(text, version)
-    has_macos = has_stanza(text, "on_macos")
-    has_linux = has_stanza(text, "on_linux")
-    url_sha_pairs = iter_primary_url_sha_pairs(text)
-    classified_pairs = [(match, classify_target(match.group("url"), target_aliases, version)) for match in url_sha_pairs]
+    text = formula_text.update_repository_metadata(text, args.repository)
+    text = formula_text.update_version(text, version)
+    has_macos = formula_text.has_stanza(text, "on_macos")
+    has_linux = formula_text.has_stanza(text, "on_linux")
+    url_sha_pairs = formula_text.iter_primary_url_sha_pairs(text)
+    classified_pairs = [(match, formula_text.classify_target(match.group("url"), target_aliases, version)) for match in url_sha_pairs]
     target_url_count = sum(1 for _, target in classified_pairs if target)
-    has_target_urls = target_url_count > 1 and not uses_stanza_url_mode(text, version)
-    if args.artifact_template and not has_target_urls and uses_stanza_url_mode(text, version):
-        text = convert_stanza_url_mode_to_targets(
+    has_target_urls = target_url_count > 1 and not formula_text.uses_stanza_url_mode(text, version)
+    if args.artifact_template and not has_target_urls and formula_text.uses_stanza_url_mode(text, version):
+        text = formula_text.convert_stanza_url_mode_to_targets(
             text,
             args.repository,
             args.tag,
@@ -1236,12 +652,12 @@ def main(argv: list[str] | None = None) -> int:
             args.artifact_template,
             target_aliases,
         )
-        url_sha_pairs = iter_primary_url_sha_pairs(text)
-        classified_pairs = [(match, classify_target(match.group("url"), target_aliases, version)) for match in url_sha_pairs]
+        url_sha_pairs = formula_text.iter_primary_url_sha_pairs(text)
+        classified_pairs = [(match, formula_text.classify_target(match.group("url"), target_aliases, version)) for match in url_sha_pairs]
         target_url_count = sum(1 for _, target in classified_pairs if target)
         has_target_urls = target_url_count > 1
     elif args.artifact_template and not has_target_urls:
-        text = insert_target_stanzas(
+        text = formula_text.insert_target_stanzas(
             text,
             args.repository,
             args.tag,
@@ -1250,8 +666,8 @@ def main(argv: list[str] | None = None) -> int:
             args.artifact_template,
             target_aliases,
         )
-        url_sha_pairs = iter_primary_url_sha_pairs(text)
-        classified_pairs = [(match, classify_target(match.group("url"), target_aliases, version)) for match in url_sha_pairs]
+        url_sha_pairs = formula_text.iter_primary_url_sha_pairs(text)
+        classified_pairs = [(match, formula_text.classify_target(match.group("url"), target_aliases, version)) for match in url_sha_pairs]
         target_url_count = sum(1 for _, target in classified_pairs if target)
         has_target_urls = target_url_count > 1
     if has_macos != has_linux and not has_target_urls:
@@ -1304,7 +720,7 @@ def main(argv: list[str] | None = None) -> int:
 
         if args.linux_url:
             linux_sha = sha256(linux_url)
-            text = replace_zero_or_one(
+            text = formula_text.replace_zero_or_one(
                 text,
                 r'(?P<prefix>url ")https://github\.com/[^"]+/archive/refs/tags/[^"]+(?P<middle>"\n\s+sha256 ")[0-9a-f]+(?P<suffix>")',
                 rf'\g<prefix>{linux_url}\g<middle>{linux_sha}\g<suffix>',
@@ -1314,11 +730,11 @@ def main(argv: list[str] | None = None) -> int:
     else:
         macos_sha = sha256(macos_url)
         if has_macos:
-            text = update_url_and_sha_in_stanza(text, "on_macos", macos_url, macos_sha, version)
+            text = formula_text.update_url_and_sha_in_stanza(text, "on_macos", macos_url, macos_sha, version)
             linux_sha = sha256(linux_url)
-            text = update_url_and_sha_in_stanza(text, "on_linux", linux_url, linux_sha, version)
+            text = formula_text.update_url_and_sha_in_stanza(text, "on_linux", linux_url, linux_sha, version)
         else:
-            text = update_top_level_url_and_sha(text, macos_url, macos_sha, version)
+            text = formula_text.update_top_level_url_and_sha(text, macos_url, macos_sha, version)
             linux_sha = None
         print(f"macOS: {macos_sha}  {macos_url}")
         if linux_sha:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ brew uninstall --cask --zap openclaw/tap/<name>
 
 ## Maintainers
 
+### Local validation and code layout
+
+The automation uses Python's standard library and Homebrew's Ruby tooling:
+
+```bash
+python3 -B -m unittest discover -s tests -v
+brew style Formula/*.rb Casks/*.rb
+brew ruby tests/test_ocm_platforms.rb
+```
+
+`update_formula.py` owns command validation, downloads, source-tag verification and
+file writes. `formula_text.py` parses and renders formula text without network or
+filesystem access. `reconcile_formulae.py` discovers release drift and invokes the
+updater. These scripts live in `.github/scripts/`; formula-specific installation
+behavior stays in `Formula/*.rb`.
+
+### Release dispatch
+
 Formula updates have two automated paths. Source-repository release workflows dispatch
 `Update Formula` for immediate updates. That workflow accepts a Homebrew formula token, a semantic release tag, and a
 GitHub repository in `owner/repo` form. Optional artifact inputs must resolve to HTTPS release
@@ -105,6 +123,8 @@ failed creation leaves no placeholder file.
 For Gitcrawl, see the [configuration reference](https://gitcrawl.sh/configuration/)
 and [gh shim migration to Octopool](https://gitcrawl.sh/gh-shim/).
 
+### Reconciliation
+
 `Reconcile Formulae` is the self-healing fallback for formulae. Every three hours
 it derives each source repository from the formula's GitHub `homepage`, compares the formula with that repository's latest
 stable published release, and runs the same updater and checksum-download logic when the release is
@@ -124,6 +144,8 @@ Pull requests and updates to `main` run the updater and reconciler tests and val
 Ruby syntax. They also load the checked-out tap on every Homebrew OS/architecture combination,
 including unsupported installation targets. Formulae must always define a URL; use an architecture
 requirement to reject unsupported installs rather than leaving platform metadata empty.
+
+### Asset handoff contracts
 
 Fleet release workflows use the optional `assets` JSON contract: exactly one `name` and `sha256`
 for each Darwin/Linux amd64/arm64 target. The updater renders those names and hashes verbatim,

--- a/tests/test_reconcile_formulae.py
+++ b/tests/test_reconcile_formulae.py
@@ -98,7 +98,7 @@ class ReconcileFormulaeTest(unittest.TestCase):
             for target in targets
         ]
         expected = original.replace(f'version "{info.current_tag[1:]}"', f'version "{newer[1:]}"')
-        for pair in reconcile_formulae.update_formula.iter_url_sha_pairs(original):
+        for pair in reconcile_formulae.update_formula.formula_text.iter_url_sha_pairs(original):
             url = pair.group("url").replace(f"/{info.current_tag}/", f"/{newer}/")
             self.assertIn(url, urls)
             expected = expected.replace(pair.group("url"), url).replace(
@@ -107,7 +107,7 @@ class ReconcileFormulaeTest(unittest.TestCase):
 
         download_order = [
             pair.group("url").replace(f"/{info.current_tag}/", f"/{newer}/")
-            for pair in reconcile_formulae.update_formula.iter_url_sha_pairs(original)
+            for pair in reconcile_formulae.update_formula.formula_text.iter_url_sha_pairs(original)
         ]
         self.assertCountEqual(download_order, urls)
         for dry_run in (False, True):
@@ -234,8 +234,8 @@ class ReconcileFormulaeTest(unittest.TestCase):
                             self.assertEqual(update.call_count, 1)
                             self.assertEqual(len(downloads), 4)
                             expected = original
-                            for match in reconcile_formulae.update_formula.iter_url_sha_pairs(original):
-                                target = reconcile_formulae.update_formula.classify_target(match.group("url"), {}, info.current_tag[1:])
+                            for match in reconcile_formulae.update_formula.formula_text.iter_url_sha_pairs(original):
+                                target = reconcile_formulae.update_formula.formula_text.classify_target(match.group("url"), {}, info.current_tag[1:])
                                 url = next(url for url in downloads if url.endswith(f"_{target}.tar.gz"))
                                 expected = expected.replace(match.group("url"), url).replace(
                                     match.group("sha"), hashlib.sha256(url.encode()).hexdigest(),

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -86,18 +86,18 @@ class UpdateFormulaTest(unittest.TestCase):
                     update_formula,
                     sha256=mock.DEFAULT,
                     verify_remote_source_tag=mock.DEFAULT,
-                    seed_formula=mock.DEFAULT,
                     update_cask=mock.DEFAULT,
                 ) as operations,
+                mock.patch.object(update_formula.formula_text, "seed_formula") as seed,
                 mock.patch.object(update_formula.urllib.request.OpenerDirector, "open") as network,
                 mock.patch.object(update_formula.subprocess, "run") as process,
                 mock.patch.object(pathlib.Path, "write_text") as write,
             ):
-                for operation in (*operations.values(), network, process, write):
+                for operation in (*operations.values(), seed, network, process, write):
                     operation.side_effect = AssertionError("side effect before obsolete-contract rejection")
                 with self.assertRaisesRegex(SystemExit, "Crabbox.*ordinary.*assets.*docs/RELEASING.md"):
                     update_formula.main(arguments)
-                for operation in (*operations.values(), network, process, write):
+                for operation in (*operations.values(), seed, network, process, write):
                     operation.assert_not_called()
         finally:
             os.chdir(previous_directory)
@@ -145,8 +145,8 @@ class UpdateFormulaTest(unittest.TestCase):
         original = (ROOT / "Formula" / "crabbox.rb").read_text()
         assets = crabbox_assets()
         expected = original
-        for match in update_formula.iter_url_sha_pairs(original):
-            target = update_formula.classify_target(match.group("url"), {}, "1.2.3")
+        for match in update_formula.formula_text.iter_url_sha_pairs(original):
+            target = update_formula.formula_text.classify_target(match.group("url"), {}, "1.2.3")
             item = assets[target]
             expected = expected.replace(match.group("url"), update_formula.explicit_asset_url(
                 "openclaw/crabbox", "v1.2.3", item["name"],
@@ -254,7 +254,7 @@ class UpdateFormulaTest(unittest.TestCase):
                 self.assertEqual(network.call_count, 4)
             finally:
                 os.chdir(previous_directory)
-            pairs = update_formula.iter_url_sha_pairs(path.read_text())
+            pairs = update_formula.formula_text.iter_url_sha_pairs(path.read_text())
             self.assertCountEqual(
                 [(match.group("url"), match.group("sha")) for match in pairs],
                 [(update_formula.explicit_asset_url("openclaw/crabbox", "v1.2.3", item["name"]), item["sha256"])
@@ -275,7 +275,7 @@ class UpdateFormulaTest(unittest.TestCase):
                     with (
                         mock.patch.object(update_formula, "verify_remote_source_tag") as verify_tag,
                         mock.patch.object(update_formula, "sha256") as download,
-                        mock.patch.object(update_formula, "seed_formula") as seed,
+                        mock.patch.object(update_formula.formula_text, "seed_formula") as seed,
                         mock.patch.object(update_formula, "update_cask") as cask,
                         mock.patch.object(pathlib.Path, "write_text") as write,
                     ):
@@ -378,7 +378,7 @@ class UpdateFormulaTest(unittest.TestCase):
         major, minor, patch = version_match.groups()
         version = f"{major}.{minor}.{int(patch) + 1}"
         hashes = {target: str(index) * 64 for index, target in enumerate(update_formula.RELEASE_TARGETS, 1)}
-        old_pairs = {(match.group("url"), match.group("sha")) for match in update_formula.iter_url_sha_pairs(formula)}
+        old_pairs = {(match.group("url"), match.group("sha")) for match in update_formula.formula_text.iter_url_sha_pairs(formula)}
         metadata = r'(?m)^\s*(?:version|url|sha256) "[^"\n]+"$'
 
         for mode in ("explicit-assets", "legacy-template", "verified-hashes"):
@@ -433,7 +433,7 @@ class UpdateFormulaTest(unittest.TestCase):
                     self.assertCountEqual([call.args[0] for call in download.call_args_list], expected)
                 pairs = [
                     (match.group("url").replace("#{version}", version), match.group("sha"))
-                    for match in update_formula.iter_url_sha_pairs(updated)
+                    for match in update_formula.formula_text.iter_url_sha_pairs(updated)
                 ]
                 self.assertCountEqual(pairs, expected.items())
                 self.assertTrue(set(pairs).isdisjoint(old_pairs))
@@ -878,7 +878,7 @@ end
             "linux_arm64": "4" * 64,
         }
 
-        updated = update_formula.render_verified_target_formula(
+        updated = update_formula.formula_text.render_verified_target_formula(
             formula,
             "openclaw/example",
             "v0.36.1",
@@ -920,7 +920,7 @@ end
         )
         for description, candidate, message in cases:
             with self.subTest(description=description), self.assertRaisesRegex(SystemExit, message):
-                update_formula.render_verified_target_formula(
+                update_formula.formula_text.render_verified_target_formula(
                     candidate,
                     "openclaw/example",
                     "v0.43.1",
@@ -940,7 +940,7 @@ end
             "linux_arm64": "4" * 64,
         }
 
-        updated = update_formula.render_verified_target_formula(
+        updated = update_formula.formula_text.render_verified_target_formula(
             formula,
             "openclaw/wacli",
             "v0.12.1",
@@ -965,7 +965,7 @@ end
             self.assertEqual(updated.count(digest), 1)
 
     def test_seed_formula_escapes_ruby_description(self) -> None:
-        seeded = update_formula.seed_formula(
+        seeded = update_formula.formula_text.seed_formula(
             "example",
             "openclaw/example",
             "1.2.3",
@@ -1059,7 +1059,7 @@ end
 end
 '''
 
-        updated = update_formula.update_url_and_sha_in_stanza(
+        updated = update_formula.formula_text.update_url_and_sha_in_stanza(
             text,
             "on_linux",
             "https://github.com/steipete/camsnap/archive/refs/tags/v0.3.0.tar.gz",
@@ -1071,7 +1071,7 @@ end
         self.assertEqual(updated.count("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"), 2)
 
     def test_target_update_handles_version_length_change(self) -> None:
-        formula = update_formula.seed_formula(
+        formula = update_formula.formula_text.seed_formula(
             "example",
             "openclaw/example",
             "0.7.9",
@@ -1108,14 +1108,14 @@ end
             "https://github.com/openclaw/example/releases/download/v0.43.0/"
             "example_0.43.0_mystery.tar.gz"
         )
-        self.assertIsNone(update_formula.classify_target(mystery_url, {}, "0.43.0"))
+        self.assertIsNone(update_formula.formula_text.classify_target(mystery_url, {}, "0.43.0"))
         formula = platform_install_formula().replace(
             '  license "MIT"',
             '  version "0.43.0"\n  license "MIT"',
         ).replace("example_0.43.0_linux_arm64.tar.gz", "example_0.43.0_mystery.tar.gz")
         classified = [
-            update_formula.classify_target(match.group("url"), {}, "0.43.0")
-            for match in update_formula.iter_url_sha_pairs(formula)
+            update_formula.formula_text.classify_target(match.group("url"), {}, "0.43.0")
+            for match in update_formula.formula_text.iter_url_sha_pairs(formula)
         ]
         self.assertEqual(classified.count(None), 1)
         self.assertEqual(len([target for target in classified if target]), 3)
@@ -1304,7 +1304,7 @@ end
 '''
 
         with self.assertRaises(SystemExit) as raised:
-            update_formula.update_url_and_sha_in_stanza(
+            update_formula.formula_text.update_url_and_sha_in_stanza(
                 text,
                 "on_linux",
                 "https://github.com/steipete/example/archive/refs/tags/v1.0.1.tar.gz",
@@ -1345,7 +1345,7 @@ end
 end
 '''
 
-        self.assertTrue(update_formula.uses_stanza_url_mode(text, "0.9.2"))
+        self.assertTrue(update_formula.formula_text.uses_stanza_url_mode(text, "0.9.2"))
 
     def test_converts_duplicate_platform_stanzas_to_target_urls(self) -> None:
         text = '''class Wacli < Formula
@@ -1380,7 +1380,7 @@ end
 end
 '''
 
-        updated = update_formula.convert_stanza_url_mode_to_targets(
+        updated = update_formula.formula_text.convert_stanza_url_mode_to_targets(
             text,
             "openclaw/wacli",
             "v0.9.3",
@@ -1417,7 +1417,7 @@ end
 end
 '''
 
-        updated = update_formula.insert_target_stanzas(
+        updated = update_formula.formula_text.insert_target_stanzas(
             text,
             "steipete/sag",
             "v0.3.1",
@@ -1444,8 +1444,8 @@ end
 end
 '''
 
-        updated = update_formula.update_version(text, "0.27.0")
-        updated = update_formula.update_top_level_url_and_sha(
+        updated = update_formula.formula_text.update_version(text, "0.27.0")
+        updated = update_formula.formula_text.update_top_level_url_and_sha(
             updated,
             "https://github.com/steipete/CodexBar/releases/download/v0.27.0/CodexBar-macos-universal-0.27.0.zip",
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -218,7 +218,8 @@ class WorkflowSecurityTest(unittest.TestCase):
                 root = pathlib.Path(directory)
                 scripts = root / ".github" / "scripts"
                 scripts.mkdir(parents=True)
-                (scripts / "update_formula.py").write_bytes((ROOT / ".github" / "scripts" / "update_formula.py").read_bytes())
+                for source in (ROOT / ".github" / "scripts").glob("*.py"):
+                    (scripts / source.name).write_bytes(source.read_bytes())
                 (root / "Formula").mkdir()
                 formula = root / "Formula" / "crabbox.rb"
                 before = expected if mode == "noop" else original


### PR DESCRIPTION
Separate formula text editing from the updater's network and filesystem operations. `formula_text.py` owns parsing and rendering; the updater validates inputs and resolves exact asset URLs before calling it, and reconciliation shares the parser directly. This makes the editing boundary easier to review while preserving formula-owned install instructions, all dispatch arguments, and the existing verification order. README now maps the modules and gives local validation commands.

Validation: all 73 Python tests pass; no test assertions were removed. The workflow subprocess fixtures copy the script modules together. AST comparison found 29 moved function bodies unchanged; the explicit-assets renderer now takes resolved URL/digest pairs. Isolated Codex autoreview at P0–P2: scoped-clean.

Live proof: the extracted updater downloaded and SHA-256 verified all four public Crabfleet v0.3.1 archives into a temporary formula update. Its resulting inventory matched the checked-in release and its install/test body was unchanged. `python3 -B .github/scripts/reconcile_formulae.py --dry-run --formula crabfleet` also performed a real GitHub lookup and reported:

```text
CURRENT crabfleet: v0.3.1
SUMMARY scanned=1 current=1 drift=0 updated=0 refused=0 skipped=0 failed=0
```
