### PR TITLE
refactor: simplify tap package definitions

### DIFF
--- a/Casks/goplaces.rb
+++ b/Casks/goplaces.rb
@@ -3,29 +3,28 @@ cask "goplaces" do
   version "0.4.9"
 
   on_macos do
-    on_intel do
-      sha256 "35ad4e631306f1654b3bb5faa13067c1cb4dfcfc6271d75ff51d55abea1a288e"
-      url "https://github.com/openclaw/goplaces/releases/download/v#{version}/goplaces_#{version}_darwin_amd64.tar.gz"
-    end
     on_arm do
       sha256 "8c133880df665101777cfb6e395f1336521870980c1866584076e9db2978250a"
       url "https://github.com/openclaw/goplaces/releases/download/v#{version}/goplaces_#{version}_darwin_arm64.tar.gz"
     end
-  end
-
-  on_linux do
     on_intel do
-      sha256 "e7d5db4927c2da8cc443016120a02fdd8062391644715b2df32f7870722ea4ac"
-      url "https://github.com/openclaw/goplaces/releases/download/v#{version}/goplaces_#{version}_linux_amd64.tar.gz"
+      sha256 "35ad4e631306f1654b3bb5faa13067c1cb4dfcfc6271d75ff51d55abea1a288e"
+      url "https://github.com/openclaw/goplaces/releases/download/v#{version}/goplaces_#{version}_darwin_amd64.tar.gz"
     end
+  end
+  on_linux do
     on_arm do
       sha256 "a83e1c0612f7f18bfc93cb2ac1174b553609c2f6159ae97037df3a12a362a4e1"
       url "https://github.com/openclaw/goplaces/releases/download/v#{version}/goplaces_#{version}_linux_arm64.tar.gz"
     end
+    on_intel do
+      sha256 "e7d5db4927c2da8cc443016120a02fdd8062391644715b2df32f7870722ea4ac"
+      url "https://github.com/openclaw/goplaces/releases/download/v#{version}/goplaces_#{version}_linux_amd64.tar.gz"
+    end
   end
 
   name "goplaces"
-  desc "Modern Go client + CLI for the Google Places API (New)."
+  desc "Modern Go client + CLI for the Google Places API (New)"
   homepage "https://github.com/openclaw/goplaces"
 
   livecheck do
@@ -33,7 +32,4 @@ cask "goplaces" do
   end
 
   binary "goplaces"
-
-  # No zap stanza required
-
 end

--- a/Formula/crabbox.rb
+++ b/Formula/crabbox.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-# Maintained in this tap; the ordinary updater preserves install behavior.
 class Crabbox < Formula
   desc "Remote software testing and execution"
   homepage "https://github.com/openclaw/crabbox"
@@ -11,20 +10,10 @@ class Crabbox < Formula
     if Hardware::CPU.intel?
       url "https://github.com/openclaw/crabbox/releases/download/v0.57.0/crabbox_0.57.0_darwin_amd64.tar.gz"
       sha256 "84656eeba91916d7c23898a13d89c5247d356890e078822c818bbe8ce0101eee"
-
-      define_method(:install) do
-        bin.install "crabbox"
-        bin.install "crabbox-apple-vm-helper" if OS.mac? && Hardware::CPU.arm?
-      end
     end
     if Hardware::CPU.arm?
       url "https://github.com/openclaw/crabbox/releases/download/v0.57.0/crabbox_0.57.0_darwin_arm64.tar.gz"
       sha256 "bba898561b4f5548047088ee761f2c3c74574c85af68fde792196b9f9b33c217"
-
-      define_method(:install) do
-        bin.install "crabbox"
-        bin.install "crabbox-apple-vm-helper" if OS.mac? && Hardware::CPU.arm?
-      end
     end
   end
 
@@ -32,19 +21,16 @@ class Crabbox < Formula
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://github.com/openclaw/crabbox/releases/download/v0.57.0/crabbox_0.57.0_linux_amd64.tar.gz"
       sha256 "3a395826da2fa7117149f160b25fc0586841664d3096754ca21bd85f1c7e9d37"
-      define_method(:install) do
-        bin.install "crabbox"
-        bin.install "crabbox-apple-vm-helper" if OS.mac? && Hardware::CPU.arm?
-      end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/openclaw/crabbox/releases/download/v0.57.0/crabbox_0.57.0_linux_arm64.tar.gz"
       sha256 "1a0618a18d556ad9c601e8882b6dc80aabfaedd3f5a447bec20bb56409df82d3"
-      define_method(:install) do
-        bin.install "crabbox"
-        bin.install "crabbox-apple-vm-helper" if OS.mac? && Hardware::CPU.arm?
-      end
     end
+  end
+
+  def install
+    bin.install "crabbox"
+    bin.install "crabbox-apple-vm-helper" if OS.mac? && Hardware::CPU.arm?
   end
 
   test do

--- a/Formula/peekaboo.rb
+++ b/Formula/peekaboo.rb
@@ -30,10 +30,7 @@ class Peekaboo < Formula
   end
 
   test do
-    # Test that the binary runs and returns version
     assert_match "Peekaboo", shell_output("#{bin}/peekaboo --version")
-
-    # Test help command
     assert_match(/\AUsage\n\s+peekaboo\b/, shell_output("#{bin}/peekaboo --help"))
   end
 end


### PR DESCRIPTION
Crabbox duplicated its install method in four platform branches. Replace those copies with one normal formula install method, preserving the macOS ARM64 helper condition and every release URL/checksum. Remove redundant Peekaboo test comments and fix Goplaces stanza ordering and description formatting; all executable tests remain intact.

Validation: all 73 Python tests pass, and `brew style Formula/*.rb Casks/*.rb` reports 19 files with no offenses (the baseline had seven cask offenses). Isolated Codex autoreview at P0–P2: scoped-clean.

Live proof: downloaded the public Crabbox v0.57.0 Darwin ARM64 archive, verified its checked-in SHA-256, and loaded both the original and candidate formula with Homebrew's `Formulary.load_formula`. Ran each real install method into a temporary bin directory; both installed exactly `crabbox` and `crabbox-apple-vm-helper`. Executed the installed CLI:

```text
0.57.0
PASS: native Homebrew install method installed CLI and Apple VM helper
PASS: public archive SHA-256 matched bba898561b4f5548047088ee761f2c3c74574c85af68fde792196b9f9b33c217
```

The proof uses the formula's install method and real archive without replacing an existing user installation. No package version changes.
