### PR TITLE
ci: validate casks and bound pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,28 +9,37 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  HOMEBREW_NO_AUTO_UPDATE: "1"
+  HOMEBREW_NO_ANALYTICS: "1"
+
 jobs:
   test:
     runs-on: macos-15
+    timeout-minutes: 20
     steps:
       - name: Checkout tap repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - name: Run updater tests
-        run: python3 -m unittest discover -s tests -v
+      - name: Run automation tests
+        run: python3 -B -m unittest discover -s tests -v
 
-      - name: Validate formula syntax
+      - name: Validate package syntax
         run: |
-          for formula in Formula/*.rb; do
-            ruby -c "$formula"
+          for package in Formula/*.rb Casks/*.rb; do
+            ruby -c "$package"
           done
 
       - name: Validate Homebrew style
-        run: brew style Formula/*.rb
+        run: brew style Formula/*.rb Casks/*.rb
 
       - name: Validate tap on every Homebrew platform
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: "1"
         run: |
           brew tap --custom-remote openclaw/tap "$GITHUB_WORKSPACE"
           brew readall --os=all --arch=all openclaw/tap

--- a/.github/workflows/ocm-smoke.yml
+++ b/.github/workflows/ocm-smoke.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     paths:
       - Formula/ocm.rb
-      - .github/scripts/update_formula.py
-      - .github/scripts/reconcile_formulae.py
+      - .github/scripts/**
       - .github/workflows/ocm-smoke.yml
       - tests/smoke_ocm.sh
   push:
@@ -13,13 +12,16 @@ on:
       - main
     paths:
       - Formula/ocm.rb
-      - .github/scripts/update_formula.py
-      - .github/scripts/reconcile_formulae.py
+      - .github/scripts/**
       - .github/workflows/ocm-smoke.yml
       - tests/smoke_ocm.sh
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   install:

--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ preserves the published executable bytes, including the macOS Developer ID signa
 Changes to the OCM formula or its updater run installed-Homebrew tests on macOS ARM64,
 macOS x86_64, and Linux x86_64, using the checked-out formula rather than the public tap.
 
-Pull requests and updates to `main` run the updater and reconciler tests and validate every formula's
-Ruby syntax. They also load the checked-out tap on every Homebrew OS/architecture combination,
+Pull requests and updates to `main` run the automation tests and validate Ruby syntax
+and Homebrew style for every formula and cask. Superseded pull-request validation runs
+are canceled, while main-branch checks finish independently. They also load the checked-out
+tap on every Homebrew OS/architecture combination,
 including unsupported installation targets. Formulae must always define a URL; use an architecture
 requirement to reject unsupported installs rather than leaving platform metadata empty.
 


### PR DESCRIPTION
CI previously ignored cask style and syntax, allowing seven Goplaces offenses to accumulate. Validate all 19 formula/cask files, give the CI job a 20-minute deadline, and cancel only superseded PR validation runs. Main runs use independent concurrency groups. OCM installed smokes now cover changes to every automation module, including the newly extracted renderer. Checkout no longer retains credentials for the read-only test job.

Dependency audit: the tap automation has no third-party Python dependencies or lockfiles. Its pinned Actions are already current: [checkout v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1) (2026-07-20) and [create-github-app-token v3.2.0](https://github.com/actions/create-github-app-token/releases/tag/v3.2.0) (2026-05-12). Their tag SHAs match every checked-in reference; both exceed the 48-hour release-age threshold. Keep the existing runner matrix and runtime floors. No package versions change.

Validation: 73 Python tests pass; all workflow files parse with Psych; Ruby accepts all 19 package definitions; `brew style Formula/*.rb Casks/*.rb` reports no offenses. Live `brew ruby tests/test_ocm_platforms.rb` passes macOS ARM64/Intel and Linux ARM64/Intel metadata loading and requirement checks. The PR's installed OCM matrix runs the real published CLI on all three supported platforms. Isolated Codex autoreview at P0–P2: scoped-clean.
