### PR TITLE
fix: prepare combined formula and cask updates before writing

### DIFF
--- a/.github/scripts/update_formula.py
+++ b/.github/scripts/update_formula.py
@@ -372,21 +372,40 @@ def parse_target_aliases(value: str | None) -> dict[str, str]:
     return aliases
 
 
-def update_cask(cask: str, repository: str, tag: str, artifact: str) -> None:
+def prepare_cask_update(cask: str, repository: str, tag: str, artifact: str) -> tuple[pathlib.Path, str]:
     validate_artifact_token(artifact, "cask artifact")
     version = tag[1:] if tag.startswith("v") else tag
     url = f"https://github.com/{repository}/releases/download/{tag}/{artifact}"
-    digest = sha256(url)
     path = tap_path("Casks", cask)
     if not path.exists():
         raise SystemExit(f"{path} does not exist; cask creation needs a manual template")
 
     text = path.read_text()
+    digest = sha256(url)
     text = formula_text.update_version(text, version)
     text = formula_text.update_top_level_url_and_sha(text, url, digest, version)
-    path.write_text(text)
     print(f"cask: {digest}  {url}")
-    print(f"updated {path} to {version}")
+    return path, text
+
+
+def write_formula_and_cask(
+    path: pathlib.Path,
+    text: str,
+    repository: str,
+    tag: str,
+    cask: str | None,
+    cask_artifact: str | None,
+) -> None:
+    updates = [(path, text)]
+    if cask:
+        assert cask_artifact is not None
+        updates.append(prepare_cask_update(cask, repository, tag, cask_artifact))
+
+    # Complete downloads and rendering for both files before changing either one.
+    for target, content in updates:
+        target.write_text(content)
+    if cask:
+        print(f"updated {updates[1][0]} to {tag.removeprefix('v')}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -530,6 +549,10 @@ def main(argv: list[str] | None = None) -> int:
     version = args.tag[1:] if args.tag.startswith("v") else args.tag
     if args.cask and not args.cask_artifact:
         raise SystemExit("--cask-artifact is required when --cask is set")
+    cask_artifact = None
+    if args.cask_artifact:
+        cask_artifact = format_template(args.cask_artifact, args.formula, version, args.tag)
+        validate_artifact_token(cask_artifact, "cask artifact")
     target_aliases = parse_target_aliases(args.target_aliases)
     if args.artifact_template:
         for target in RELEASE_TARGETS:
@@ -600,19 +623,9 @@ def main(argv: list[str] | None = None) -> int:
                 for target, item in explicit_assets.items()
             },
         )
-        path.write_text(text)
+        write_formula_and_cask(path, text, args.repository, args.tag, args.cask, cask_artifact)
         print(f"updated {path} to {version} from exact verified release assets")
-        if args.cask:
-            assert args.cask_artifact is not None
-            cask_artifact = format_template(args.cask_artifact, args.formula, version, args.tag)
-            validate_artifact_token(cask_artifact, "cask artifact")
-            update_cask(args.cask, args.repository, args.tag, cask_artifact)
         return 0
-
-    cask_artifact = None
-    if args.cask_artifact:
-        cask_artifact = format_template(args.cask_artifact, args.formula, version, args.tag)
-        validate_artifact_token(cask_artifact, "cask artifact")
 
     macos_artifact = args.macos_artifact or f"{args.formula}-macos-universal.tar.gz"
     validate_artifact_token(macos_artifact, "macOS artifact")
@@ -740,13 +753,10 @@ def main(argv: list[str] | None = None) -> int:
         if linux_sha:
             print(f"Linux: {linux_sha}  {linux_url}")
 
-    path.write_text(text)
+    write_formula_and_cask(path, text, args.repository, args.tag, args.cask, cask_artifact)
     if created:
         print(f"created {path}")
     print(f"updated {path} to {version}")
-    if args.cask:
-        assert cask_artifact is not None
-        update_cask(args.cask, args.repository, args.tag, cask_artifact)
     return 0
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Highlights:** Restore normal tap installation for every package, install OCM and Peekaboo, and recover release updates without publishing partial formulae.
 
+- Preserve both files when a combined formula/cask update fails during input validation, download, or rendering.
 - Fix `brew tap openclaw/tap` rejecting the entire tap when validating OCM on Linux ARM64; retain the Linux x86_64 installation requirement and validate all Homebrew platforms in CI; thanks @jandubois.
 - Update OCM to v0.2.45 for macOS ARM64/Intel and Linux x86_64, including environment artifact exports, stopped-session recovery, environment-variable UI paths, and safer environment roots. Preserve signed release binaries; use `brew upgrade openclaw/tap/ocm`.
 - Add the Peekaboo universal macOS formula, update it to 4.3.2, and match its v4 help header in the installed smoke test.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ preserves that content while changing release metadata. In legacy multi-target m
 `linux_url` refreshes both the matching GitHub source-archive URL and its checksum. Maintain
 formula-specific content here rather than in an upstream release workflow. Newly generated
 formulae remain in memory until all required checksum downloads and rendering succeed, so
-failed creation leaves no placeholder file.
+failed creation leaves no placeholder file. Combined formula/cask updates also finish
+all downloads and rendering before writing either file, so a missing or invalid cask
+leaves the formula unchanged.
 For Gitcrawl, see the [configuration reference](https://gitcrawl.sh/configuration/)
 and [gh shim migration to Octopool](https://gitcrawl.sh/gh-shim/).
 

--- a/tests/test_combined_update.py
+++ b/tests/test_combined_update.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+import urllib.error
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("combined_updater", ROOT / ".github/scripts/update_formula.py")
+assert SPEC and SPEC.loader
+updater = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(updater)
+
+CASK = '''cask "example" do
+  version "1.2.2"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  url "https://github.com/openclaw/example/releases/download/v#{version}/example.zip"
+end
+'''
+
+
+class CombinedUpdateTest(unittest.TestCase):
+    def test_combined_updates_prepare_both_files_before_writing(self) -> None:
+        for mode in ("legacy", "explicit"):
+            for existing in (False, True):
+                for failure in (None, "download", "missing-cask", "invalid-cask", "invalid-artifact"):
+                    with self.subTest(mode=mode, existing=existing, failure=failure), tempfile.TemporaryDirectory() as directory:
+                        root = pathlib.Path(directory)
+                        (root / "Formula").mkdir()
+                        (root / "Casks").mkdir()
+                        formula = root / "Formula/example.rb"
+                        cask = root / "Casks/example.rb"
+                        if existing:
+                            formula.write_text(updater.formula_text.seed_formula(
+                                "example", "openclaw/example", "1.2.2", "Example", "{formula}_{version}_{target}.tar.gz",
+                            ))
+                        if failure != "missing-cask":
+                            cask.write_text('cask "example" do\nend\n' if failure == "invalid-cask" else CASK)
+                        before = {p.relative_to(root): p.read_bytes() for p in root.rglob("*.rb")}
+                        arguments = [
+                            "--formula", "example", "--tag", "v1.2.3", "--repository", "openclaw/example",
+                            "--cask", "example", "--cask-artifact",
+                            "bad/name.zip" if failure == "invalid-artifact" else "example.zip",
+                        ]
+                        if mode == "explicit":
+                            arguments += ["--assets-json", json.dumps({
+                                target: {"name": f"example_1.2.3_{target}.tar.gz", "sha256": "b" * 64}
+                                for target in updater.RELEASE_TARGETS
+                            })]
+
+                        downloads = []
+
+                        def download(url: str) -> str:
+                            self.assertEqual({p.relative_to(root): p.read_bytes() for p in root.rglob("*.rb")}, before)
+                            downloads.append(url)
+                            if url.endswith("/example.zip"):
+                                if failure == "download":
+                                    raise urllib.error.URLError("cask download failed")
+                                return "c" * 64
+                            return "b" * 64
+
+                        previous = pathlib.Path.cwd()
+                        os.chdir(root)
+                        try:
+                            with mock.patch.object(updater, "sha256", side_effect=download), contextlib.redirect_stdout(io.StringIO()):
+                                if failure:
+                                    with self.assertRaises((SystemExit, urllib.error.URLError)):
+                                        updater.main(arguments)
+                                else:
+                                    self.assertEqual(updater.main(arguments), 0)
+                        finally:
+                            os.chdir(previous)
+                        if failure:
+                            self.assertEqual({p.relative_to(root): p.read_bytes() for p in root.rglob("*.rb")}, before)
+                        else:
+                            self.assertEqual(len(downloads), 5)
+                            self.assertEqual(formula.read_text().count('sha256 "' + 'b' * 64), 4)
+                            self.assertIn('version "1.2.3"', formula.read_text())
+                            self.assertIn('version "1.2.3"', cask.read_text())
+                            self.assertIn('sha256 "' + 'c' * 64, cask.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -86,7 +86,7 @@ class UpdateFormulaTest(unittest.TestCase):
                     update_formula,
                     sha256=mock.DEFAULT,
                     verify_remote_source_tag=mock.DEFAULT,
-                    update_cask=mock.DEFAULT,
+                    prepare_cask_update=mock.DEFAULT,
                 ) as operations,
                 mock.patch.object(update_formula.formula_text, "seed_formula") as seed,
                 mock.patch.object(update_formula.urllib.request.OpenerDirector, "open") as network,
@@ -222,7 +222,7 @@ class UpdateFormulaTest(unittest.TestCase):
                         try:
                             with (
                                 mock.patch.object(update_formula.urllib.request.OpenerDirector, "open", side_effect=download) as network,
-                                mock.patch.object(update_formula, "update_cask") as cask,
+                                mock.patch.object(update_formula, "prepare_cask_update") as cask,
                                 self.assertRaisesRegex(
                                     (SystemExit, urllib.error.HTTPError),
                                     "SHA-256 mismatch|404|must contain exactly",
@@ -276,7 +276,7 @@ class UpdateFormulaTest(unittest.TestCase):
                         mock.patch.object(update_formula, "verify_remote_source_tag") as verify_tag,
                         mock.patch.object(update_formula, "sha256") as download,
                         mock.patch.object(update_formula.formula_text, "seed_formula") as seed,
-                        mock.patch.object(update_formula, "update_cask") as cask,
+                        mock.patch.object(update_formula, "prepare_cask_update") as cask,
                         mock.patch.object(pathlib.Path, "write_text") as write,
                     ):
                         self.assertEqual(update_formula.main(crabbox_arguments("verified-hashes") + ["--verify-source-tag-only"]), 0)


### PR DESCRIPTION
A combined formula/cask update wrote the formula before downloading and rendering the cask. A missing cask archive or invalid cask therefore left the local checkout partially updated, including newly created formulae.

Prepare the cask's complete candidate text before writing either file, using one shared write path for legacy and explicit-assets modes. Validate the formatted cask filename before download work. This preserves both files when validation, download or rendering fails; it does not claim a cross-file filesystem transaction for disk-write failures. README and Unreleased describe the behavior.

Regression proof: the new 20-scenario test failed 18 scenarios on the old implementation. It covers existing/new formulae, both update modes, success, missing/invalid casks, invalid filenames and cask download failures. All 74 tests now pass. Existing assertions remain intact. Isolated Codex autoreview at P0–P2: scoped-clean.

Live proof used temporary formula/cask copies, the real four public Crabfleet v0.3.1 archives, and a real missing cask URL:

```text
Before: Public formula archives verified; real cask HTTP 404; both files preserved=False
After:  Public formula archives verified; real cask HTTP 404; both files preserved=True
Retry with a real published cask archive succeeded; both metadata files updated together
```

The retry used the published Darwin ARM64 archive as the synthetic cask payload and verified the resulting cask digest. No tap dispatch, package version change, or publication was performed.
