### PR TITLE
fix: isolate resource metadata from formula release updates

### DIFF
--- a/.github/scripts/formula_text.py
+++ b/.github/scripts/formula_text.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 
 
 RELEASE_TARGETS = ("darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64")
@@ -20,20 +21,22 @@ def ruby_string(value: str) -> str:
 
 
 def replace_once(text: str, pattern: str, replacement: str, description: str) -> str:
-    matches = re.findall(pattern, text, flags=re.MULTILINE | re.DOTALL)
+    matches = primary_matches(text, re.finditer(pattern, text, flags=re.MULTILINE | re.DOTALL))
     if len(matches) != 1:
         raise SystemExit(f"expected exactly one {description}, found {len(matches)}")
-    return re.sub(pattern, replacement, text, count=1, flags=re.MULTILINE | re.DOTALL)
+    match = matches[0]
+    return text[:match.start()] + match.expand(replacement) + text[match.end():]
 
 
 def replace_zero_or_one(text: str, pattern: str, replacement: str, description: str) -> str:
-    matches = re.findall(pattern, text, flags=re.MULTILINE | re.DOTALL)
+    matches = primary_matches(text, re.finditer(pattern, text, flags=re.MULTILINE | re.DOTALL))
     if len(matches) > 1:
         raise SystemExit(f"expected at most one {description}, found {len(matches)}")
     if not matches:
         print(f"no explicit {description}; leaving it unchanged")
         return text
-    return re.sub(pattern, replacement, text, count=1, flags=re.MULTILINE | re.DOTALL)
+    match = matches[0]
+    return text[:match.start()] + match.expand(replacement) + text[match.end():]
 
 
 def target_markers(target: str, alias: str | None = None) -> tuple[str, ...]:
@@ -74,16 +77,21 @@ def iter_url_sha_pairs(text: str) -> list[re.Match[str]]:
     )
 
 
-def iter_primary_url_sha_pairs(text: str) -> list[re.Match[str]]:
+def primary_matches(text: str, matches: Iterable[re.Match[str]]) -> list[re.Match[str]]:
+    """Exclude resource stanzas while retaining offsets into the original formula."""
     resources = list(re.finditer(
-        r'^(?P<indent>[ \t]+)resource [^\n]+\n.*?^(?P=indent)end(?:[ \t]*\n|$)',
+        r'^(?P<indent>[ \t]+)resource [^\n]+\n.*?^(?P=indent)end[ \t]*(?:#[^\n]*)?(?:\n|$)',
         text,
         re.MULTILINE | re.DOTALL,
     ))
     return [
-        pair for pair in iter_url_sha_pairs(text)
-        if not any(resource.start() <= pair.start() < resource.end() for resource in resources)
+        match for match in matches
+        if not any(resource.start() <= match.start() < resource.end() for resource in resources)
     ]
+
+
+def iter_primary_url_sha_pairs(text: str) -> list[re.Match[str]]:
+    return primary_matches(text, iter_url_sha_pairs(text))
 
 
 def stanza_body(text: str, stanza: str) -> str | None:
@@ -121,7 +129,7 @@ def replace_url_preserving_interpolation(
     version: str,
     description: str,
 ) -> str:
-    matches = list(re.finditer(pattern, text, flags=re.MULTILINE | re.DOTALL))
+    matches = primary_matches(text, re.finditer(pattern, text, flags=re.MULTILINE | re.DOTALL))
     if len(matches) != 1:
         raise SystemExit(f"expected exactly one {description}, found {len(matches)}")
 

--- a/.github/scripts/reconcile_formulae.py
+++ b/.github/scripts/reconcile_formulae.py
@@ -117,7 +117,7 @@ def parse_semver(value: str) -> SemanticVersion:
 def source_release_urls(text: str, repository: str, version: str) -> list[tuple[str, str]]:
     prefix = f"https://github.com/{repository}/releases/download/"
     urls: list[tuple[str, str]] = []
-    for pair in formula_text.iter_url_sha_pairs(text):
+    for pair in formula_text.iter_primary_url_sha_pairs(text):
         url = pair.group("url").replace("#{version}", version)
         if not url.lower().startswith(prefix.lower()):
             continue
@@ -194,12 +194,16 @@ def infer_update_options(
 
 def parse_formula(path: pathlib.Path) -> FormulaInfo:
     text = path.read_text()
-    homepages = HOMEPAGE_PATTERN.findall(text)
+    homepages = [
+        match.group(1) for match in formula_text.primary_matches(text, HOMEPAGE_PATTERN.finditer(text))
+    ]
     if len(homepages) != 1:
         raise ValueError(f"expected one GitHub homepage, found {len(homepages)}")
     repository = homepages[0]
 
-    versions = VERSION_PATTERN.findall(text)
+    versions = [
+        match.group(1) for match in formula_text.primary_matches(text, VERSION_PATTERN.finditer(text))
+    ]
     if len(versions) > 1:
         raise ValueError(f"expected at most one formula version, found {len(versions)}")
     explicit_version = versions[0] if versions else None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Highlights:** Restore normal tap installation for every package, install OCM and Peekaboo, and recover release updates without publishing partial formulae.
 
 - Preserve both files when a combined formula/cask update fails during input validation, download, or rendering.
+- Keep formula resources out of reconciliation's release inference so independently pinned resource assets do not block package updates.
 - Fix `brew tap openclaw/tap` rejecting the entire tap when validating OCM on Linux ARM64; retain the Linux x86_64 installation requirement and validate all Homebrew platforms in CI; thanks @jandubois.
 - Update OCM to v0.2.45 for macOS ARM64/Intel and Linux x86_64, including environment artifact exports, stopped-session recovery, environment-variable UI paths, and safer environment roots. Preserve signed release binaries; use `brew upgrade openclaw/tap/ocm`.
 - Add the Peekaboo universal macOS formula, update it to 4.3.2, and match its v4 help header in the installed smoke test.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ and [gh shim migration to Octopool](https://gitcrawl.sh/gh-shim/).
 it derives each source repository from the formula's GitHub `homepage`, compares the formula with that repository's latest
 stable published release, and runs the same updater and checksum-download logic when the release is
 newer. Invalid formula metadata is reported and skipped so later formulae are still inspected.
+Resource URLs are excluded from release inference, including resources from the same
+source repository; their pinned versions and checksums remain unchanged.
 It never downgrades, skips drafts and prereleases, and makes no commit when every formula is
 current. Manual reconciles default to dry-run and can target one formula. The reconciler reads public
 release metadata and pushes with this tap's own `GITHUB_TOKEN`; it needs no cross-repository token or

--- a/tests/test_reconcile_formulae.py
+++ b/tests/test_reconcile_formulae.py
@@ -88,6 +88,45 @@ class ReconcileFormulaeTest(unittest.TestCase):
                 self.assertEqual(info.name, path.stem)
                 self.assertTrue(info.update_options)
 
+    def test_resources_do_not_control_release_inference_or_get_updated(self) -> None:
+        resource = (
+            '  resource "helper" do\n'
+            '    version "0.9.0"\n'
+            '    url "https://github.com/openclaw/example/releases/download/v0.9.0/helper_darwin_arm64.tar.gz"\n'
+            f'    sha256 "{"f" * 64}"\n'
+            '  end\n'
+        )
+        for nested, comment in ((False, ""), (False, " # helper resource"), (True, ""), (True, " # helper resource")):
+            with self.subTest(nested=nested, comment=comment):
+                candidate_resource = resource.replace("  end\n", f"  end{comment}\n")
+                if nested:
+                    block = "".join("  " + line for line in candidate_resource.splitlines(keepends=True))
+                    original = formula_text().replace("  on_macos do\n", "  on_macos do\n" + block)
+                else:
+                    block = candidate_resource
+                    original = formula_text().replace("  on_macos do\n", block + "  on_macos do\n")
+                directory, root = self.make_tap(original)
+                self.addCleanup(directory.cleanup)
+                path = root / "Formula/example.rb"
+                info = reconcile_formulae.parse_formula(path)
+                self.assertEqual(info.current_tag, "v1.2.3")
+                self.assertEqual(info.update_options, ("--artifact-template", "example_v{version}_{target}.tar.gz"))
+
+                previous = pathlib.Path.cwd()
+                os.chdir(root)
+                try:
+                    with mock.patch.object(reconcile_formulae.update_formula, "sha256", return_value="e" * 64) as download:
+                        self.assertEqual(reconcile_formulae.update_formula.main([
+                            "--formula", info.name, "--repository", info.repository,
+                            "--tag", "v1.2.4", *info.update_options,
+                        ]), 0)
+                    self.assertEqual(download.call_count, 4)
+                    self.assertTrue(all("/v1.2.4/" in call.args[0] for call in download.call_args_list))
+                finally:
+                    os.chdir(previous)
+                self.assertIn(block, path.read_text())
+                self.assertIn('version "1.2.4"', path.read_text())
+
     def test_ocm_reconciliation_preserves_three_targets_and_installed_binary_policy(self) -> None:
         original = (ROOT / "Formula" / "ocm.rb").read_text()
         info = reconcile_formulae.parse_formula(ROOT / "Formula" / "ocm.rb")

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -1456,6 +1456,31 @@ end
         self.assertIn('sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"', updated)
         self.assertIn("CodexBar-macos-universal-#{version}.zip", updated)
 
+    def test_single_archive_update_preserves_resource_metadata(self) -> None:
+        resource = (
+            '  resource "helper" do\n'
+            '    version "0.9.0"\n'
+            '    url "https://example.org/helper.tar.gz"\n'
+            f'    sha256 "{"f" * 64}"\n'
+            '  end # helper resource\n'
+        )
+        original = (
+            'class Example < Formula\n'
+            + resource
+            + '  version "1.2.2"\n'
+            '  url "https://example.org/example-#{version}.tar.gz"\n'
+            f'  sha256 "{"a" * 64}"\n'
+            'end\n'
+        )
+        updated = update_formula.formula_text.update_version(original, "1.2.3")
+        updated = update_formula.formula_text.update_top_level_url_and_sha(
+            updated, "https://example.org/example-1.2.3.tar.gz", "b" * 64, "1.2.3",
+        )
+        self.assertIn(resource, updated)
+        self.assertIn('  version "1.2.3"', updated)
+        self.assertIn('  sha256 "' + 'b' * 64, updated)
+        self.assertIn('  url "https://example.org/example-#{version}.tar.gz"', updated)
+
     def test_sha256_download_budget_is_documented(self) -> None:
         self.assertEqual(update_formula.DOWNLOAD_TIMEOUT_SECONDS, 30)
 


### PR DESCRIPTION
Reconciliation treated same-repository resource archives as primary package releases. A separately pinned resource could create conflicting release tags or duplicate architecture assets, so the formula was skipped. Explicit resource versions also made version inference and formula updates reject otherwise valid metadata.

Share one resource-exclusion boundary across primary URL inventory, version/homepage lookup and regex substitutions. Keep match offsets into the original text so only the package's metadata changes. Resource URLs, checksums and explicit versions stay untouched. Existing verified-hash exact-inventory restrictions remain intact.

Regression proof: top-level and nested resource fixtures failed before the fix with conflicting release tags; an explicit resource version also reproduced the duplicate-version failure. Tests now prove four primary archives update while the entire resource block remains unchanged, including a single-archive formula whose resource precedes primary metadata. The review also found that trailing comments on resource `end` lines broke the boundary; three failing scenarios reproduced it, and the parser and regression coverage now include those comments. All 76 Python tests pass. Isolated Codex autoreview at P0–P2: scoped-clean.

Live CLI proof: ran reconciliation in a temporary checkout containing the current Crabfleet formula plus a resource bound to its real published Darwin ARM64 archive. Before the fix it skipped the formula as a duplicate target. After the fix, including an explicit resource version, the real GitHub latest-release lookup reported:

```text
CURRENT crabfleet: v0.3.1
SUMMARY scanned=1 current=1 drift=0 updated=0 refused=0 skipped=0 failed=0
PASS: checkout unchanged
```

No publication, package version changes, or live tap dispatch.

A final live `python3 -B .github/scripts/reconcile_formulae.py --dry-run` sweep also checked every current package against GitHub:

```text
SUMMARY scanned=18 current=18 drift=0 updated=0 refused=0 skipped=0 failed=0
```
